### PR TITLE
Allow struct delegation from model attributes hash

### DIFF
--- a/lib/trax/model/attributes/types/json.rb
+++ b/lib/trax/model/attributes/types/json.rb
@@ -94,7 +94,13 @@ module Trax
 
             properties_to_define.each do |_property|
               getter_method, setter_method = _property.to_sym, :"#{_property}="
-              model.delegate(getter_method, setter_method, :to => attribute_name)
+
+              model.__send__(:define_method, setter_method) do |val|
+                self[attribute_name] = {} unless self[attribute_name]
+                self.__send__(attribute_name).__send__(setter_method, val)
+              end
+
+              model.delegate(getter_method, :to => attribute_name)
             end
           end
         end

--- a/lib/trax_model/version.rb
+++ b/lib/trax_model/version.rb
@@ -1,3 +1,3 @@
 module TraxModel
-  VERSION = '0.0.93'
+  VERSION = '0.0.94'
 end

--- a/spec/support/pg/models.rb
+++ b/spec/support/pg/models.rb
@@ -17,9 +17,10 @@ module Ecommerce
 
     define_attributes do
       struct :specifics, :model_accessors => true, :validate => true do
-        string :cost, :default => 0
-
-        validates(:cost, :length => {:minimum => 10})
+        integer :cost, :default => 0
+        validates(:cost, :numericality => {:greater_than => 0})
+        integer :tax
+        string :delivery_time
 
         enum :service do
           define :usps,  1

--- a/spec/trax/model/attributes/types/integer_spec.rb
+++ b/spec/trax/model/attributes/types/integer_spec.rb
@@ -4,9 +4,7 @@ describe ::Trax::Model::Attributes::Types::Integer do
   subject{ ::Products::MensShoes::Fields::Quantity }
 
   context "model" do
-    subject {
-      ::Products::MensShoes.new(:in_stock_quantity => 1)
-    }
+    subject { ::Products::MensShoes.new(:in_stock_quantity => 1) }
 
     it { expect(subject.in_stock_quantity).to eq 1 }
 
@@ -17,8 +15,6 @@ describe ::Trax::Model::Attributes::Types::Integer do
   end
 
   context "struct attribute", :postgres => true do
-    subject {
-      ::Ecommerce::Products::MensShoes.new(:in_stock_quantity => 1)
-    }
+    subject { ::Ecommerce::Products::MensShoes.new(:in_stock_quantity => 1) }
   end
 end

--- a/spec/trax/model/attributes/types/json_spec.rb
+++ b/spec/trax/model/attributes/types/json_spec.rb
@@ -15,6 +15,20 @@ describe ::Trax::Model::Attributes::Types::Json, :postgres => true do
           expect(subject.__send__(_property)).to eq subject.specifics.__send__(_property)
         end
       }
+
+      context "initializing model and setting delegated attributes directly", :delegated_attributes =>  { :cost => 5, :tax => 5, :delivery_time => "5 days" } do
+        self::DELEGATED_ATTRIBUTES = { :cost => 5, :tax => 5, :delivery_time => "5 days" }
+
+        subject{ |example|
+          # binding.pry
+           ::Ecommerce::ShippingAttributes.new(example.example_group::DELEGATED_ATTRIBUTES) }
+
+        self::DELEGATED_ATTRIBUTES.each_pair do |k,v|
+          it "#{k} should be set" do
+            expect(subject.specifics.__send__(k)).to eq v
+          end
+        end
+      end
     end
   end
 
@@ -87,7 +101,7 @@ describe ::Trax::Model::Attributes::Types::Json, :postgres => true do
       end
 
       context "valid struct attribute" do
-        let(:subject_attributes) { { :specifics => { :cost => "asdasdasdasdasd", :dimensions => { :length => 10 }}} }
+        let(:subject_attributes) { { :specifics => { :cost => 1, :dimensions => { :length => 10 }}} }
 
         it { expect(subject.valid?).to eq true }
       end

--- a/spec/trax/model/attributes/types/json_spec.rb
+++ b/spec/trax/model/attributes/types/json_spec.rb
@@ -19,9 +19,7 @@ describe ::Trax::Model::Attributes::Types::Json, :postgres => true do
       context "initializing model and setting delegated attributes directly", :delegated_attributes =>  { :cost => 5, :tax => 5, :delivery_time => "5 days" } do
         self::DELEGATED_ATTRIBUTES = { :cost => 5, :tax => 5, :delivery_time => "5 days" }
 
-        subject{ |example|
-          # binding.pry
-           ::Ecommerce::ShippingAttributes.new(example.example_group::DELEGATED_ATTRIBUTES) }
+        subject{ |example| ::Ecommerce::ShippingAttributes.new(example.example_group::DELEGATED_ATTRIBUTES) }
 
         self::DELEGATED_ATTRIBUTES.each_pair do |k,v|
           it "#{k} should be set" do

--- a/spec/trax/model/errors_spec.rb
+++ b/spec/trax/model/errors_spec.rb
@@ -4,6 +4,6 @@ describe ::Trax::Model::Errors do
   subject{ Trax::Model::Errors::InvalidPrefix }
 
   it do
-    expect{subject.new(:blah => "blah")}.to raise_error
+    expect{subject.new(:blah => "blah")}.to raise_error(NoMethodError)
   end
 end

--- a/spec/trax/model/freezable_spec.rb
+++ b/spec/trax/model/freezable_spec.rb
@@ -12,7 +12,7 @@ describe ::Trax::Model::Freezable do
       subject.title = "somethingelse"
       subject.save
 
-      subject.errors.messages[:title].should include("Cannot be modified")
+      expect(subject.errors.messages[:title]).to include("Cannot be modified")
     end
   end
 end

--- a/spec/trax/model/restorable_spec.rb
+++ b/spec/trax/model/restorable_spec.rb
@@ -8,13 +8,13 @@ describe ::Trax::Model::Restorable do
   context "when destroyed" do
     it "should soft delete" do
       subject.destroy
-      subject.deleted.should be true
+      expect(subject.deleted).to be true
     end
 
     it "should be restorable" do
       subject.destroy
       subject.restore
-      subject.deleted.should be false
+      expect(subject.deleted).to be false
     end
   end
 
@@ -26,18 +26,18 @@ describe ::Trax::Model::Restorable do
 
       it do
         subject
-        Message.all.pluck(:id).should include(subject.id)
+        expect(Message.all.pluck(:id)).to include(subject.id)
       end
 
       it do
         subject.destroy
-        Message.all.pluck(:id).should_not include(subject.id)
+        expect(Message.all.pluck(:id)).to_not include(subject.id)
       end
     end
 
     it ".by_is_deleted" do
       subject.destroy
-      Message.by_is_deleted.pluck(:id).should include(subject.id)
+      expect(Message.by_is_deleted.pluck(:id)).to include(subject.id)
     end
   end
 end

--- a/spec/trax/validators/email_validator_spec.rb
+++ b/spec/trax/validators/email_validator_spec.rb
@@ -6,7 +6,7 @@ describe ::EmailValidator do
   ["bill@somewhere", "bill", "@initech.com", "!!!@!!!.com"].each do |bad_email|
     it "should fail validation for #{bad_email}" do
       widget = ::Widget.create(:email_address => bad_email)
-      widget.valid?.should eq false
+      expect(widget.valid?).to eq false
     end
   end
 end

--- a/spec/trax/validators/subdomain_spec.rb
+++ b/spec/trax/validators/subdomain_spec.rb
@@ -7,7 +7,7 @@ describe ::SubdomainValidator do
   ["bad!", "-asdasd", "www", "ac"].each do |bad_subdomain|
     it "should fail validation for #{bad_subdomain}" do
       widget = ::Widget.create(:subdomain => bad_subdomain)
-      widget.valid?.should eq false
+      expect(widget.valid?).to eq false
     end
   end
 end


### PR DESCRIPTION
can now set model attributes directly, i.e. before you would have to do:

``` ruby
VideoPost.new(:custom_fields => { :length_in_seconds => 50000 })
```

Because the custom fields struct would not be initialized immediately, causing a delegated to nil error. 

Now:
(assuming VideoPost has a custom fields struct, and is delegating model_accessors, i.e.:

``` ruby
define_attributes do
  struct :custom_fields, :model_accessors => true do
    integer :length_in_seconds
  end
end
```

``` ruby
VideoPost.new(:length_in_seconds => 500)
```

Will work