### PR TITLE
Field default relation scopes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'hashie', :github => "intridea/hashie"
-gem 'trax_core', :github => "jasonayre/trax_core"
+gem 'hashie', :github => "jasonayre/hashie"
+# gem 'trax_core', :github => "jasonayre/trax_core"
 # gem 'trax_core', :path => "~/gems/trax_core"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'hashie', :github => "intridea/hashie"
+gem 'trax_core', :github => "jasonayre/trax_core"
+# gem 'trax_core', :path => "~/gems/trax_core"
+
 gemspec

--- a/lib/trax/model.rb
+++ b/lib/trax/model.rb
@@ -23,6 +23,7 @@ module Trax
 
     autoload :Attributes
     autoload :Config
+    autoload :CoreExtensions
     autoload :ExtensionsFor
     autoload :Errors
     autoload :Registry
@@ -146,7 +147,7 @@ module Trax
       end
     end
 
-    ::String.include(::Trax::Model::ExtensionsFor::String)
+    ::String.include(::Trax::Model::CoreExtensions::String)
 
     ::ActiveSupport.run_load_hooks(:trax_model, self)
   end

--- a/lib/trax/model/attributes/types/boolean.rb
+++ b/lib/trax/model/attributes/types/boolean.rb
@@ -18,6 +18,7 @@ module Trax
           end
 
           class Attribute < ::Trax::Model::Attributes::Attribute
+            # binding.pry
             include ::Trax::Model::ExtensionsFor::Boolean
             self.type = :boolean
 

--- a/lib/trax/model/attributes/types/boolean.rb
+++ b/lib/trax/model/attributes/types/boolean.rb
@@ -18,6 +18,7 @@ module Trax
           end
 
           class Attribute < ::Trax::Model::Attributes::Attribute
+            include ::Trax::Model::ExtensionsFor::Boolean
             self.type = :boolean
 
             def self.to_schema

--- a/lib/trax/model/attributes/types/boolean.rb
+++ b/lib/trax/model/attributes/types/boolean.rb
@@ -18,7 +18,6 @@ module Trax
           end
 
           class Attribute < ::Trax::Model::Attributes::Attribute
-            # binding.pry
             include ::Trax::Model::ExtensionsFor::Boolean
             self.type = :boolean
 

--- a/lib/trax/model/attributes/types/enum.rb
+++ b/lib/trax/model/attributes/types/enum.rb
@@ -1,5 +1,3 @@
-require 'hashie/extensions/ignore_undeclared'
-
 module Trax
   module Model
     module Attributes

--- a/lib/trax/model/attributes/types/integer.rb
+++ b/lib/trax/model/attributes/types/integer.rb
@@ -16,8 +16,8 @@ module Trax
           end
 
           class Value < ::Trax::Model::Attributes::Value
-            include ::Trax::Model::ExtensionsFor::Numeric
-            
+            include ::Trax::Model::ExtensionsFor::Integer
+
             def self.type; :integer end;
           end
 

--- a/lib/trax/model/attributes/types/integer.rb
+++ b/lib/trax/model/attributes/types/integer.rb
@@ -16,6 +16,8 @@ module Trax
           end
 
           class Value < ::Trax::Model::Attributes::Value
+            include ::Trax::Model::ExtensionsFor::Numeric
+            
             def self.type; :integer end;
           end
 

--- a/lib/trax/model/attributes/types/set.rb
+++ b/lib/trax/model/attributes/types/set.rb
@@ -18,7 +18,7 @@ module Trax
           end
 
           class Value < ::Trax::Model::Attributes::Value
-            include ::Trax::Model::ExtensionsFor::Enumerable
+            include ::Trax::Model::ExtensionsFor::Set
 
             def initialize(*args)
               @value = ::Set.new(*args)

--- a/lib/trax/model/attributes/types/string.rb
+++ b/lib/trax/model/attributes/types/string.rb
@@ -16,6 +16,8 @@ module Trax
           end
 
           class Value < ::Trax::Model::Attributes::Value
+            include ::Trax::Model::ExtensionsFor::String
+            
             def self.type; :string end;
           end
 

--- a/lib/trax/model/core_extensions.rb
+++ b/lib/trax/model/core_extensions.rb
@@ -1,0 +1,9 @@
+module Trax
+  module Model
+    module CoreExtensions
+      extend ::ActiveSupport::Autoload
+
+      autoload :String
+    end
+  end
+end

--- a/lib/trax/model/core_extensions/string.rb
+++ b/lib/trax/model/core_extensions/string.rb
@@ -1,0 +1,17 @@
+module Trax
+  module Model
+    module ExtensionsForPrimitive
+      module String
+        extend ::ActiveSupport::Concern
+
+        def to_matchable
+          "%#{self.strip}%"
+        end
+
+        def uuid
+          ::Trax::Model::UUID === self ? ::Trax::Model::UUID.new(self) : nil
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/core_extensions/string.rb
+++ b/lib/trax/model/core_extensions/string.rb
@@ -1,6 +1,6 @@
 module Trax
   module Model
-    module ExtensionsForPrimitive
+    module CoreExtensions
       module String
         extend ::ActiveSupport::Concern
 

--- a/lib/trax/model/extensions_for.rb
+++ b/lib/trax/model/extensions_for.rb
@@ -7,7 +7,9 @@ module Trax
       autoload :Base
       autoload :Boolean
       autoload :Enumerable
+      autoload :Integer
       autoload :Numeric
+      autoload :Set
       autoload :Struct
       autoload :StructFields
       autoload :String

--- a/lib/trax/model/extensions_for.rb
+++ b/lib/trax/model/extensions_for.rb
@@ -7,6 +7,7 @@ module Trax
       autoload :Base
       autoload :Boolean
       autoload :Enumerable
+      autoload :Numeric
       autoload :Struct
       autoload :StructFields
       autoload :String

--- a/lib/trax/model/extensions_for.rb
+++ b/lib/trax/model/extensions_for.rb
@@ -1,4 +1,4 @@
-#primitive/trax core type extensions
+#trax model attribute dsl/trax core type extensions
 module Trax
   module Model
     module ExtensionsFor

--- a/lib/trax/model/extensions_for.rb
+++ b/lib/trax/model/extensions_for.rb
@@ -7,6 +7,7 @@ module Trax
       autoload :Base
       autoload :Enumerable
       autoload :Struct
+      autoload :StructFields
       autoload :String
     end
   end

--- a/lib/trax/model/extensions_for.rb
+++ b/lib/trax/model/extensions_for.rb
@@ -5,6 +5,7 @@ module Trax
       extend ::ActiveSupport::Autoload
 
       autoload :Base
+      autoload :Boolean
       autoload :Enumerable
       autoload :Struct
       autoload :StructFields

--- a/lib/trax/model/extensions_for/boolean.rb
+++ b/lib/trax/model/extensions_for/boolean.rb
@@ -8,8 +8,7 @@ module Trax
         module ClassMethods
           def eq(*_scope_values)
             _scope_values.flat_compact_uniq!
-            cast_type = type
-            model_class.where("(#{field_name})::#{cast_type} IN(?)", _scope_values)
+            model_class.where({field_name => _scope_values})
           end
 
           def is_nil

--- a/lib/trax/model/extensions_for/boolean.rb
+++ b/lib/trax/model/extensions_for/boolean.rb
@@ -1,0 +1,30 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module Boolean
+        extend ::ActiveSupport::Concern
+        include ::Trax::Model::ExtensionsFor::Base
+
+        module ClassMethods
+          def eq(*_scope_values)
+            _scope_values.flat_compact_uniq!
+            cast_type = type
+            model_class.where("(#{field_name})::#{cast_type} IN(?)", _scope_values)
+          end
+
+          def is_nil
+            eq(nil)
+          end
+
+          def is_false
+            eq(false)
+          end
+
+          def is_true
+            eq(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/enumerable.rb
+++ b/lib/trax/model/extensions_for/enumerable.rb
@@ -7,7 +7,7 @@ module Trax
         include ::Trax::Model::ExtensionsFor::Base
 
         module ClassMethods
-          def where_contains(*_values)
+          def contains(*_values)
             _values.flat_compact_uniq!
             model_class.where("#{field_name} ?| array[:values]", :values => _values)
           end

--- a/lib/trax/model/extensions_for/integer.rb
+++ b/lib/trax/model/extensions_for/integer.rb
@@ -1,0 +1,10 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module Integer
+        extend ::ActiveSupport::Concern
+        include ::Trax::Model::ExtensionsFor::Numeric
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/numeric.rb
+++ b/lib/trax/model/extensions_for/numeric.rb
@@ -1,0 +1,51 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module Numeric
+        extend ::ActiveSupport::Concern
+
+        include ::Trax::Model::ExtensionsFor::Base
+
+        module ClassMethods
+          def between(lower_value, upper_value)
+            gt(lower_value).merge(lt(upper_value))
+          end
+
+          def in_range(lower_value, upper_value)
+            gte(lower_value).merge(lte(upper_value))
+          end
+
+          def eq(*_scope_values)
+            _scope_values.flat_compact_uniq!
+            cast_type = type
+            model_class.where("(#{field_name})::#{cast_type} IN(?)", _scope_values)
+          end
+
+          def gt(value)
+            cast_type = type
+            operator = '>'
+            model_class.where("(#{field_name})::#{cast_type} #{operator} ?", value)
+          end
+
+          def gte(value)
+            cast_type = type
+            operator = '>='
+            model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+          end
+
+          def lt(value)
+            cast_type = type
+            operator = '<'
+            model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+          end
+
+          def lte(value)
+            cast_type = type
+            operator = '<='
+            model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/numeric.rb
+++ b/lib/trax/model/extensions_for/numeric.rb
@@ -17,32 +17,27 @@ module Trax
 
           def eq(*_scope_values)
             _scope_values.flat_compact_uniq!
-            cast_type = type
-            model_class.where("(#{field_name})::#{cast_type} IN(?)", _scope_values)
+            model_class.where({field_name => _scope_values})
           end
 
           def gt(value)
-            cast_type = type
             operator = '>'
-            model_class.where("(#{field_name})::#{cast_type} #{operator} ?", value)
+            model_class.where("#{field_name} #{operator} ?", value)
           end
 
           def gte(value)
-            cast_type = type
             operator = '>='
-            model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            model_class.where("#{field_name} #{operator} ?", value)
           end
 
           def lt(value)
-            cast_type = type
             operator = '<'
-            model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            model_class.where("#{field_name} #{operator} ?", value)
           end
 
           def lte(value)
-            cast_type = type
             operator = '<='
-            model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            model_class.where("#{field_name} #{operator} ?", value)
           end
         end
       end

--- a/lib/trax/model/extensions_for/set.rb
+++ b/lib/trax/model/extensions_for/set.rb
@@ -1,0 +1,10 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module Set
+        extend ::ActiveSupport::Concern
+        include ::Trax::Model::ExtensionsFor::Enumerable
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/string.rb
+++ b/lib/trax/model/extensions_for/string.rb
@@ -11,6 +11,18 @@ module Trax
             _values.flat_compact_uniq!
             model_class.where({field_name => _values})
           end
+
+          def eq_lower(*_values)
+            _values.flat_compact_uniq!
+            _values.map!(&:downcase)
+            model_class.where("lower(#{field_name}) IN(?)", _values)
+          end
+
+          def matches(*_values)
+            _values.flat_compact_uniq!
+            _values.map!(&:to_matchable)
+            model_class.where("(#{field_name}) ilike ANY(array[?])", _values)
+          end
         end
       end
     end

--- a/lib/trax/model/extensions_for/string.rb
+++ b/lib/trax/model/extensions_for/string.rb
@@ -4,8 +4,13 @@ module Trax
       module String
         extend ::ActiveSupport::Concern
 
-        def uuid
-          ::Trax::Model::UUID === self ? ::Trax::Model::UUID.new(self) : nil
+        include ::Trax::Model::ExtensionsFor::Base
+
+        module ClassMethods
+          def eq(*_values)
+            _values.flat_compact_uniq!
+            model_class.where({field_name => _values})
+          end
         end
       end
     end

--- a/lib/trax/model/extensions_for/struct.rb
+++ b/lib/trax/model/extensions_for/struct.rb
@@ -23,9 +23,22 @@ module Trax
         end
 
         module ClassMethods
+          # def [](val)
+          #   fields[val]
+          # end
           #bit of a hack for the sake of strong params for now
           def permitted_keys
             @permitted_keys ||= properties.map(&:to_sym)
+          end
+
+          def property(property_name, *args, **options)
+            super(property_name, *args, **options)
+
+            extensions_for_property_type = ::Trax::Model::ExtensionsFor::StructFields[self.fields[property_name].type]
+
+            if extensions_for_property_type
+              self.fields[property_name].include(extensions_for_property_type)
+            end
           end
 
           def define_model_scopes_for(*attribute_names)

--- a/lib/trax/model/extensions_for/struct.rb
+++ b/lib/trax/model/extensions_for/struct.rb
@@ -23,9 +23,9 @@ module Trax
         end
 
         module ClassMethods
-          # def [](val)
-          #   fields[val]
-          # end
+          def [](val)
+            fields[val]
+          end
           #bit of a hack for the sake of strong params for now
           def permitted_keys
             @permitted_keys ||= properties.map(&:to_sym)

--- a/lib/trax/model/extensions_for/struct_fields.rb
+++ b/lib/trax/model/extensions_for/struct_fields.rb
@@ -1,0 +1,15 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        extend ::ActiveSupport::Autoload
+
+        autoload :Time
+
+        def self.[](val)
+          "#{name}::#{val.to_s.classify}".safe_constantize
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields.rb
+++ b/lib/trax/model/extensions_for/struct_fields.rb
@@ -6,6 +6,7 @@ module Trax
 
         autoload :Float
         autoload :Numeric
+        autoload :String
         autoload :Time
 
         def self.[](val)

--- a/lib/trax/model/extensions_for/struct_fields.rb
+++ b/lib/trax/model/extensions_for/struct_fields.rb
@@ -4,8 +4,10 @@ module Trax
       module StructFields
         extend ::ActiveSupport::Autoload
 
+        autoload :Boolean
         autoload :Enum
         autoload :Float
+        autoload :Integer
         autoload :Numeric
         autoload :String
         autoload :Time

--- a/lib/trax/model/extensions_for/struct_fields.rb
+++ b/lib/trax/model/extensions_for/struct_fields.rb
@@ -4,6 +4,7 @@ module Trax
       module StructFields
         extend ::ActiveSupport::Autoload
 
+        autoload :Enum
         autoload :Float
         autoload :Numeric
         autoload :String

--- a/lib/trax/model/extensions_for/struct_fields.rb
+++ b/lib/trax/model/extensions_for/struct_fields.rb
@@ -4,6 +4,8 @@ module Trax
       module StructFields
         extend ::ActiveSupport::Autoload
 
+        autoload :Float
+        autoload :Numeric
         autoload :Time
 
         def self.[](val)

--- a/lib/trax/model/extensions_for/struct_fields/boolean.rb
+++ b/lib/trax/model/extensions_for/struct_fields/boolean.rb
@@ -1,0 +1,32 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Boolean
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::Base
+
+          module ClassMethods
+            def eq(*_scope_values)
+              _scope_values.flat_compact_uniq!
+              cast_type = type
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} IN(?)", _scope_values)
+            end
+
+            def is_nil
+              eq(nil)
+            end
+
+            def is_true
+              eq(true)
+            end
+
+            def is_false
+              eq(false)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/enum.rb
+++ b/lib/trax/model/extensions_for/struct_fields/enum.rb
@@ -1,0 +1,20 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Enum
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::Base
+
+          module ClassMethods
+            def eq(*_scope_values)
+              _integer_values = select_values(*_scope_values.flat_compact_uniq!)
+              _integer_values.map!(&:to_s)
+              model_class.where("#{parent_definition.field_name} -> '#{field_name}' IN(?)", _integer_values)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/float.rb
+++ b/lib/trax/model/extensions_for/struct_fields/float.rb
@@ -1,0 +1,12 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Float
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::StructFields::Numeric
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/integer.rb
+++ b/lib/trax/model/extensions_for/struct_fields/integer.rb
@@ -1,0 +1,12 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Integer
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::StructFields::Numeric
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/numeric.rb
+++ b/lib/trax/model/extensions_for/struct_fields/numeric.rb
@@ -1,0 +1,44 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Numeric
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::Base
+
+          module ClassMethods
+            def eq(*_scope_values)
+              _scope_values.flat_compact_uniq!
+              cast_type = type
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} IN(?)", _scope_values)
+            end
+
+            def gt(value)
+              cast_type = type
+              operator = '>'
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            end
+
+            def gte(value)
+              cast_type = type
+              operator = '>='
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            end
+
+            def lt(value)
+              cast_type = type
+              operator = '<'
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            end
+
+            def lte(value)
+              cast_type = type
+              operator = '<='
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/numeric.rb
+++ b/lib/trax/model/extensions_for/struct_fields/numeric.rb
@@ -7,6 +7,14 @@ module Trax
           include ::Trax::Model::ExtensionsFor::Base
 
           module ClassMethods
+            def between(lower_value, upper_value)
+              gt(lower_value).merge(lt(upper_value))
+            end
+
+            def in_range(lower_value, upper_value)
+              gte(lower_value).merge(lte(upper_value))
+            end
+
             def eq(*_scope_values)
               _scope_values.flat_compact_uniq!
               cast_type = type

--- a/lib/trax/model/extensions_for/struct_fields/string.rb
+++ b/lib/trax/model/extensions_for/struct_fields/string.rb
@@ -1,0 +1,29 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module String
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::Base
+
+          module ClassMethods
+            def eq(*_scope_values)
+              _scope_values.flat_compact_uniq!
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}') IN(?)", _scope_values)
+            end
+
+            def eq_lower(*_scope_values)
+              _scope_values.flat_compact_uniq!
+              model_class.where("lower(#{parent_definition.field_name} ->> '#{field_name}') IN(?)", _scope_values.map(&:downcase))
+            end
+
+            def matches(*_scope_values)
+              _scope_values.flat_compact_uniq!
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}') ilike ANY(array[?])", _scope_values.map(&:to_matchable))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/time.rb
+++ b/lib/trax/model/extensions_for/struct_fields/time.rb
@@ -4,22 +4,19 @@ module Trax
       module StructFields
         module Time
           extend ::ActiveSupport::Concern
-
           include ::Trax::Model::ExtensionsFor::Base
 
           module ClassMethods
-            def after(*_scope_values)
-              _scope_values.flat_compact_uniq!
+            def after(value)
               cast_type = 'timestamp'
               operator = '>'
-              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", _scope_values)
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
             end
 
-            def before(*_scope_values)
-              _scope_values.flat_compact_uniq!
+            def before(value)
               cast_type = 'timestamp'
               operator = '<'
-              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", _scope_values)
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
             end
 
             def between(first_time, second_time)

--- a/lib/trax/model/extensions_for/struct_fields/time.rb
+++ b/lib/trax/model/extensions_for/struct_fields/time.rb
@@ -22,6 +22,30 @@ module Trax
             def between(first_time, second_time)
               after(first_time).merge(before(second_time))
             end
+
+            def gt(value)
+              after(value)
+            end
+
+            def gte(value)
+              cast_type = 'timestamp'
+              operator = '>='
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            end
+
+            def in_range(first_time, second_time)
+              gte(first_time).merge(lte(second_time))
+            end
+
+            def lt(value)
+              before(value)
+            end
+
+            def lte(value)
+              cast_type = 'timestamp'
+              operator = '<='
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", value)
+            end
           end
         end
       end

--- a/lib/trax/model/extensions_for/struct_fields/time.rb
+++ b/lib/trax/model/extensions_for/struct_fields/time.rb
@@ -7,33 +7,7 @@ module Trax
 
           include ::Trax::Model::ExtensionsFor::Base
 
-          # return unless has_active_record_ancestry?(parent_definition)
-
-          # included do
-          #   # model_class = model_class_for_property(property_klass)
-          #   attribute_klass = parent_definition
-          #   # field_name = property_klass.parent_definition.name.demodulize.underscore
-          #   attribute_name = property_klass.name.demodulize.underscore
-          #   cast_type = 'timestamp'
-          #
-          #   { :gt => '>', :lt => '<'}.each_pair do |k, operator|
-          #     scope_prefix = as ? as : :"by_#{field_name}_#{attribute_name}"
-          #     scope_name = "#{scope_prefix}_#{k}"
-          #     # scope_alias = "#{scope_prefix}_#{{:gt => 'after', :lt => 'before' }[k]}"
-          #
-          #     model_class.scope(scope_name, lambda{ |*_scope_values|
-          #       _scope_values.flat_compact_uniq!
-          #       model_class.where("(#{field_name} ->> '#{attribute_name}')::#{cast_type} #{operator} ?", _scope_values)
-          #     })
-          #     model_class.singleton_class.__send__("alias_method", scope_alias.to_sym, scope_name)
-          #   end
-          # end
-
           module ClassMethods
-            # def gt
-            #   model_class.all
-            # end
-
             def after(*_scope_values)
               _scope_values.flat_compact_uniq!
               cast_type = 'timestamp'
@@ -46,6 +20,10 @@ module Trax
               cast_type = 'timestamp'
               operator = '<'
               model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", _scope_values)
+            end
+
+            def between(first_time, second_time)
+              after(first_time).merge(before(second_time))
             end
           end
         end

--- a/lib/trax/model/extensions_for/struct_fields/time.rb
+++ b/lib/trax/model/extensions_for/struct_fields/time.rb
@@ -1,0 +1,55 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Time
+          extend ::ActiveSupport::Concern
+
+          include ::Trax::Model::ExtensionsFor::Base
+
+          # return unless has_active_record_ancestry?(parent_definition)
+
+          # included do
+          #   # model_class = model_class_for_property(property_klass)
+          #   attribute_klass = parent_definition
+          #   # field_name = property_klass.parent_definition.name.demodulize.underscore
+          #   attribute_name = property_klass.name.demodulize.underscore
+          #   cast_type = 'timestamp'
+          #
+          #   { :gt => '>', :lt => '<'}.each_pair do |k, operator|
+          #     scope_prefix = as ? as : :"by_#{field_name}_#{attribute_name}"
+          #     scope_name = "#{scope_prefix}_#{k}"
+          #     # scope_alias = "#{scope_prefix}_#{{:gt => 'after', :lt => 'before' }[k]}"
+          #
+          #     model_class.scope(scope_name, lambda{ |*_scope_values|
+          #       _scope_values.flat_compact_uniq!
+          #       model_class.where("(#{field_name} ->> '#{attribute_name}')::#{cast_type} #{operator} ?", _scope_values)
+          #     })
+          #     model_class.singleton_class.__send__("alias_method", scope_alias.to_sym, scope_name)
+          #   end
+          # end
+
+          module ClassMethods
+            # def gt
+            #   model_class.all
+            # end
+
+            def after(*_scope_values)
+              _scope_values.flat_compact_uniq!
+              cast_type = 'timestamp'
+              operator = '>'
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", _scope_values)
+            end
+
+            def before(*_scope_values)
+              _scope_values.flat_compact_uniq!
+              cast_type = 'timestamp'
+              operator = '<'
+              model_class.where("(#{parent_definition.field_name} ->> '#{field_name}')::#{cast_type} #{operator} ?", _scope_values)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/matchable.rb
+++ b/lib/trax/model/matchable.rb
@@ -3,23 +3,16 @@ module Trax
     module Matchable
       extend ::ActiveSupport::Concern
 
-      included do
-        ::String.class_eval do
-          def to_matchable
-            "%#{self.strip}%"
-          end
-        end
-      end
-
       module ClassMethods
         def matching(args = {})
           matches = args.inject(self.all) do |scope, (key, value)|
             node = key.is_a?(Symbol) ? self.arel_table[key] : key
 
             values = [value]
+            values.flat_compact_uniq!
+            values.map!(&:to_matchable)
 
-            match_values = values.flatten.compact.uniq.map!(&:to_matchable)
-            scope = scope.where(node.matches_any(match_values))
+            scope = scope.where(node.matches_any(values))
             scope
           end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -35,6 +35,10 @@ class Product < ::ActiveRecord::Base
 
   define_attributes do
     string :name
+    # float :price
+
+    integer :in_stock_quantity
+    integer :out_of_stock_quantity
 
     enum :status, :default => :in_stock do
       define :in_stock,     1

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -34,6 +34,8 @@ class Product < ::ActiveRecord::Base
   }
 
   define_attributes do
+    string :name
+
     enum :status, :default => :in_stock do
       define :in_stock,     1
       define :out_of_stock, 2

--- a/spec/support/pg/models.rb
+++ b/spec/support/pg/models.rb
@@ -93,6 +93,8 @@ module Ecommerce
         integer :number_of_sales, :default => 0
         float :price
         time :last_received_at
+        string :slug
+        string :display_name
 
         define_model_scope_for :in_stock_quantity, :as => :by_quantity_in_stock
         define_model_scope_for :last_received_at, :as => :by_last_received_at

--- a/spec/support/pg/models.rb
+++ b/spec/support/pg/models.rb
@@ -89,9 +89,9 @@ module Ecommerce
 
       struct :custom_fields do
         integer :cost
-        integer :price
         integer :in_stock_quantity, :default => 0
         integer :number_of_sales, :default => 0
+        float :price
         time :last_received_at
 
         define_model_scope_for :in_stock_quantity, :as => :by_quantity_in_stock

--- a/spec/trax/model/attributes/types/set_spec.rb
+++ b/spec/trax/model/attributes/types/set_spec.rb
@@ -46,22 +46,22 @@ describe ::Trax::Model::Attributes::Types::Set, :postgres => true do
     }
     it {
       expect(
-        ::Ecommerce::Vote::Fields::UpvoterIds.where_contains("1")
+        ::Ecommerce::Vote::Fields::UpvoterIds.contains("1")
       ).to include record_one
     }
     it {
       expect(
-        ::Ecommerce::Vote::Fields::UpvoterIds.where_contains("1")
+        ::Ecommerce::Vote::Fields::UpvoterIds.contains("1")
       ).to_not include record_two
     }
     it {
       expect(
-        ::Ecommerce::Vote::Fields::UpvoterIds.where_contains("4")
+        ::Ecommerce::Vote::Fields::UpvoterIds.contains("4")
       ).to include record_two
     }
     it {
       expect(
-        ::Ecommerce::Vote::Fields::UpvoterIds.where_contains("4")
+        ::Ecommerce::Vote::Fields::UpvoterIds.contains("4")
       ).to_not include record_one
     }
   end

--- a/spec/trax/model/extensions_for/boolean_spec.rb
+++ b/spec/trax/model/extensions_for/boolean_spec.rb
@@ -13,4 +13,14 @@ describe ::Trax::Model::ExtensionsFor::Boolean do
   context ".eq" do
     it { expect(subject.fields[:active].eq(true, false)).to include(product_one, product_two) }
   end
+
+  context ".is_true" do
+    it { expect(subject.fields[:active].is_true).to include(product_one) }
+    it { expect(subject.fields[:active].is_true).to_not include(product_two) }
+  end
+
+  context ".is_false" do
+    it { expect(subject.fields[:active].is_false).to_not include(product_one) }
+    it { expect(subject.fields[:active].is_false).to include(product_two) }
+  end
 end

--- a/spec/trax/model/extensions_for/boolean_spec.rb
+++ b/spec/trax/model/extensions_for/boolean_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe ::Trax::Model::ExtensionsFor::Boolean do
+  subject{ ::Product }
+
+  let!(:product_one) {
+    ::Product.create(:name => "DC Villan Size 6", :active => true)
+  }
+  let!(:product_two) {
+    ::Product.create(:name => "DC Villan Size 7", :active => false)
+  }
+
+  context ".eq" do
+    it { expect(subject.fields[:active].eq(true, false)).to include(product_one, product_two) }
+  end
+end

--- a/spec/trax/model/extensions_for/numeric_spec.rb
+++ b/spec/trax/model/extensions_for/numeric_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe ::Trax::Model::ExtensionsFor::Numeric do
+  subject{ ::Product }
+
+  let!(:product_one) {
+    ::Product.create(:name => "DC Villan Size 6", :in_stock_quantity => 5)
+  }
+  let!(:product_two) {
+    ::Product.create(:name => "DC Villan Size 7", :in_stock_quantity => 9)
+  }
+
+  context "Integer" do
+    context ".between" do
+      it { expect(subject.fields[:in_stock_quantity].between(5, 10)).to include(product_two) }
+      it { expect(subject.fields[:in_stock_quantity].between(5, 10)).to_not include(product_one) }
+      # it { expect(subject.fields[:in_stock_quantity].eq(5)).to_not include(product_two) }
+      # it { expect(subject.fields[:in_stock_quantity].eq(5,9)).to include(product_two, product_one) }
+    end
+
+    context ".eq" do
+      it { expect(subject.fields[:in_stock_quantity].eq(5)).to include(product_one) }
+      it { expect(subject.fields[:in_stock_quantity].eq(5)).to_not include(product_two) }
+      it { expect(subject.fields[:in_stock_quantity].eq(5,9)).to include(product_two, product_one) }
+    end
+
+    context ".gt" do
+      it { expect(subject.fields[:in_stock_quantity].gt(5)).to include(product_two) }
+      it { expect(subject.fields[:in_stock_quantity].gt(5)).to_not include(product_one) }
+    end
+
+    context ".lt" do
+      it { expect(subject.fields[:in_stock_quantity].lt(9)).to include(product_one) }
+      it { expect(subject.fields[:in_stock_quantity].lt(5)).to_not include(product_two) }
+    end
+  end
+
+  # context "Integer" do
+  #   context ".eq" do
+  #     it { expect(subject.fields[:in_stock_quantity].eq(5)).to include(product_one) }
+  #     it { expect(subject.fields[:in_stock_quantity].eq(5)).to_not include(product_two) }
+  #     it { expect(subject.fields[:in_stock_quantity].eq(5,9)).to include(product_two, product_one) }
+  #   end
+  #
+  #   context ".gt" do
+  #     it { expect(subject.fields[:in_stock_quantity].gt(5)).to include(product_two) }
+  #     it { expect(subject.fields[:in_stock_quantity].gt(5)).to_not include(product_one) }
+  #   end
+  #
+  #   context ".lt" do
+  #     it { expect(subject.fields[:in_stock_quantity].lt(9)).to include(product_one) }
+  #     it { expect(subject.fields[:in_stock_quantity].lt(5)).to_not include(product_two) }
+  #   end
+  # end
+end

--- a/spec/trax/model/extensions_for/numeric_spec.rb
+++ b/spec/trax/model/extensions_for/numeric_spec.rb
@@ -14,8 +14,6 @@ describe ::Trax::Model::ExtensionsFor::Numeric do
     context ".between" do
       it { expect(subject.fields[:in_stock_quantity].between(5, 10)).to include(product_two) }
       it { expect(subject.fields[:in_stock_quantity].between(5, 10)).to_not include(product_one) }
-      # it { expect(subject.fields[:in_stock_quantity].eq(5)).to_not include(product_two) }
-      # it { expect(subject.fields[:in_stock_quantity].eq(5,9)).to include(product_two, product_one) }
     end
 
     context ".eq" do

--- a/spec/trax/model/extensions_for/string_spec.rb
+++ b/spec/trax/model/extensions_for/string_spec.rb
@@ -19,7 +19,7 @@ describe ::Trax::Model::ExtensionsFor::String do
     it { expect(subject.fields[:name].eq_lower("dc Villan Size 6")).to include(product_one) }
   end
 
-  context ".matches" do
+  context ".matches", :postgres => true do
     it { expect(subject.fields[:name].matches("dc")).to include(product_one, product_two) }
   end
 end

--- a/spec/trax/model/extensions_for/string_spec.rb
+++ b/spec/trax/model/extensions_for/string_spec.rb
@@ -12,6 +12,14 @@ describe ::Trax::Model::ExtensionsFor::String do
 
   context ".eq" do
     it { expect(subject.fields[:name].eq("DC Villan Size 6")).to include(product_one) }
+    it { expect(subject.fields[:name].eq("DC Villan Size 7")).to_not include(product_one) }
   end
 
+  context ".eq_lower" do
+    it { expect(subject.fields[:name].eq_lower("dc Villan Size 6")).to include(product_one) }
+  end
+
+  context ".matches" do
+    it { expect(subject.fields[:name].matches("dc")).to include(product_one, product_two) }
+  end
 end

--- a/spec/trax/model/extensions_for/string_spec.rb
+++ b/spec/trax/model/extensions_for/string_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe ::Trax::Model::ExtensionsFor::String do
+  subject{ ::Product }
+
+  let!(:product_one) {
+    ::Product.create(:name => "DC Villan Size 6")
+  }
+  let!(:product_two) {
+    ::Product.create(:name => "DC Villan Size 7")
+  }
+
+  context ".eq" do
+    it { expect(subject.fields[:name].eq("DC Villan Size 6")).to include(product_one) }
+  end
+
+end

--- a/spec/trax/model/extensions_for/struct_spec.rb
+++ b/spec/trax/model/extensions_for/struct_spec.rb
@@ -1,16 +1,35 @@
 require 'spec_helper'
 describe ::Trax::Model::ExtensionsFor::Struct do
-  subject {
-    ::StoreCategory.new(
-      "name" => "watches",
-      "meta_attributes" => {
-        "description" => "Watches and stuff",
-        "keywords" => [ 'nixon', 'vestal' ]
+  subject{ ::Ecommerce::Products::MensShoes }
+
+  let(:product_one_last_received_at) { ::Time.now - 10.days }
+  let(:product_two_last_received_at) { ::Time.now - 5.days }
+  let(:product_one_size) { :mens_6 }
+  let(:product_two_size) { :mens_7 }
+
+  let!(:product_one) {
+    ::Ecommerce::Products::MensShoes.create(
+      "name" => "DC Villan Size 6",
+      "custom_fields" => {
+        "size" => product_one_size,
+        "last_received_at" => product_one_last_received_at
       }
     )
   }
 
-  its("name") {  should eq "watches" }
-  its("meta_attributes.description") { should eq "Watches and stuff" }
-  its("meta_attributes.class") { should eq StoreCategory::Fields::MetaAttributes }
+  let!(:product_two) {
+    ::Ecommerce::Products::MensShoes.create(
+      "name" => "DC Villan Size 7",
+      "custom_fields" => {
+        "size" => product_two_size,
+        "last_received_at" => product_two_last_received_at
+      }
+    )
+  }
+
+  context "time" do
+    it {
+      expect(subject.fields[:custom_fields].fields[:last_received_at].after(::Time.now - 6.days)).to include(product_two)
+    }
+  end
 end

--- a/spec/trax/model/extensions_for/struct_spec.rb
+++ b/spec/trax/model/extensions_for/struct_spec.rb
@@ -170,5 +170,20 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
         expect(subject.fields[:custom_fields].fields[:price].lte(29.99)).to_not include(product_two)
       }
     end
+
+    context "between" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].between(28.99, 30.00)).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].between(29.99, 30.00)).to_not include(product_one)
+      }
+    end
+
+    context "in_range" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].in_range(29.99, 30.00)).to include(product_one)
+      }
+    end
   end
 end

--- a/spec/trax/model/extensions_for/struct_spec.rb
+++ b/spec/trax/model/extensions_for/struct_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-describe ::Trax::Model::ExtensionsFor::Struct do
+
+describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
   subject{ ::Ecommerce::Products::MensShoes }
 
   let(:product_one_last_received_at) { ::Time.now - 10.days }
@@ -12,7 +13,9 @@ describe ::Trax::Model::ExtensionsFor::Struct do
       "name" => "DC Villan Size 6",
       "custom_fields" => {
         "size" => product_one_size,
-        "last_received_at" => product_one_last_received_at
+        "last_received_at" => product_one_last_received_at,
+        "cost" => 15,
+        "price" => 29.99
       }
     )
   }
@@ -22,14 +25,54 @@ describe ::Trax::Model::ExtensionsFor::Struct do
       "name" => "DC Villan Size 7",
       "custom_fields" => {
         "size" => product_two_size,
-        "last_received_at" => product_two_last_received_at
+        "last_received_at" => product_two_last_received_at,
+        "cost" => 20,
+        "price" => 39.99
       }
     )
   }
 
   context "time" do
-    it {
-      expect(subject.fields[:custom_fields].fields[:last_received_at].after(::Time.now - 6.days)).to include(product_two)
-    }
+    context "after" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:last_received_at].after(::Time.now - 6.days)).to include(product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:last_received_at].after(::Time.now - 6.days)).to_not include(product_one)
+      }
+    end
+
+    context "before" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:last_received_at].before(::Time.now - 6.days)).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:last_received_at].before(::Time.now - 6.days)).to_not include(product_two)
+      }
+    end
+
+    context "between" do
+      let(:start_time) { ::Time.now - 6.days}
+      let(:end_time) { ::Time.now - 4.days }
+      it {
+        expect(subject.fields[:custom_fields].fields[:last_received_at].between(start_time, end_time)).to include(product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:last_received_at].between(start_time, end_time)).to_not include(product_one)
+      }
+    end
+  end
+
+  context "float" do
+    context "gt" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].gt(30.00)).to include(product_two)
+      }
+
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].gt(30.00)).to_not include(product_one)
+      }
+
+    end
   end
 end

--- a/spec/trax/model/extensions_for/struct_spec.rb
+++ b/spec/trax/model/extensions_for/struct_spec.rb
@@ -64,15 +64,55 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
   end
 
   context "float" do
+    context "eq" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].eq(29.99)).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].eq(29.99)).to_not include(product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].eq(29.99, 39.99)).to include(product_two)
+      }
+    end
+
     context "gt" do
       it {
-        expect(subject.fields[:custom_fields].fields[:price].gt(30.00)).to include(product_two)
+        expect(subject.fields[:custom_fields].fields[:price].gt(29.99)).to include(product_two)
       }
-
       it {
-        expect(subject.fields[:custom_fields].fields[:price].gt(30.00)).to_not include(product_one)
+        expect(subject.fields[:custom_fields].fields[:price].gt(29.99)).to_not include(product_one)
       }
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].gt(29.99)).to_not include(product_one)
+      }
+    end
 
+    context "gte" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].gte(39.99)).to include(product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].gte(39.99)).to_not include(product_one)
+      }
+    end
+
+    context "lt" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].lt(39.99)).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].gt(39.99)).to_not include(product_two)
+      }
+    end
+
+    context "lte" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].lte(29.99)).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:price].lte(29.99)).to_not include(product_two)
+      }
     end
   end
 end

--- a/spec/trax/model/extensions_for/struct_spec.rb
+++ b/spec/trax/model/extensions_for/struct_spec.rb
@@ -36,6 +36,23 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
     )
   }
 
+  context "enum" do
+    context "eq" do
+      it {
+        expect(subject.fields[:custom_fields][:size].eq(product_two_size)).to include(product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields][:size].eq(product_two_size)).to_not include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields][:size].eq(product_two_size, product_one_size)).to include(product_one, product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields][:size].eq(1,2)).to include(product_one, product_two)
+      }
+    end
+  end
+
   context "string" do
     context "eq" do
       it {
@@ -69,8 +86,6 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
         expect(subject.fields[:custom_fields].fields[:slug].matches("blah")).to_not include(product_one, product_two)
       }
     end
-
-
   end
 
   context "time" do

--- a/spec/trax/model/extensions_for/struct_spec.rb
+++ b/spec/trax/model/extensions_for/struct_spec.rb
@@ -13,6 +13,8 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
       "name" => "DC Villan Size 6",
       "custom_fields" => {
         "size" => product_one_size,
+        "slug" => "dc-villan-size-6",
+        "display_name" => "DC Villan Mens Shoes Size 6",
         "last_received_at" => product_one_last_received_at,
         "cost" => 15,
         "price" => 29.99
@@ -25,12 +27,51 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
       "name" => "DC Villan Size 7",
       "custom_fields" => {
         "size" => product_two_size,
+        "slug" => "dc-villan-size-7",
+        "display_name" => "DC Villan Mens Shoes Size 7",
         "last_received_at" => product_two_last_received_at,
         "cost" => 20,
         "price" => 39.99
       }
     )
   }
+
+  context "string" do
+    context "eq" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:slug].eq("dc-villan-size-6")).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:slug].eq("dc-villan-size-6")).to_not include(product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:slug].eq("dc-villan-size-6", "dc-villan-size-7")).to include(product_two, product_one)
+      }
+    end
+
+    context "eq_lower" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:display_name].eq_lower("dc villan mens shoes size 6")).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:display_name].eq_lower("DC Villan Mens Shoes Size 6", "DC Villan Mens Shoes Size 7")).to include(product_one, product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:display_name].eq_lower("DC Villan Mens Shoes Size 7")).to_not include(product_one)
+      }
+    end
+
+    context "matches" do
+      it {
+        expect(subject.fields[:custom_fields].fields[:slug].matches("dc-villan-size")).to include(product_one, product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields].fields[:slug].matches("blah")).to_not include(product_one, product_two)
+      }
+    end
+
+
+  end
 
   context "time" do
     context "after" do

--- a/spec/trax/model/extensions_for/struct_spec.rb
+++ b/spec/trax/model/extensions_for/struct_spec.rb
@@ -14,6 +14,7 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
       "custom_fields" => {
         "size" => product_one_size,
         "slug" => "dc-villan-size-6",
+        "has_shoelaces" => true,
         "display_name" => "DC Villan Mens Shoes Size 6",
         "last_received_at" => product_one_last_received_at,
         "cost" => 15,
@@ -28,6 +29,7 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
       "custom_fields" => {
         "size" => product_two_size,
         "slug" => "dc-villan-size-7",
+        "has_shoelaces" => false,
         "display_name" => "DC Villan Mens Shoes Size 7",
         "last_received_at" => product_two_last_received_at,
         "cost" => 20,
@@ -35,6 +37,38 @@ describe ::Trax::Model::ExtensionsFor::Struct, :postgres => true do
       }
     )
   }
+
+  context "boolean" do
+    context "eq" do
+      it {
+        expect(subject.fields[:custom_fields][:has_shoelaces].eq(true, false)).to include(product_one, product_two)
+      }
+    end
+
+    context "is_true" do
+      it {
+        expect(subject.fields[:custom_fields][:has_shoelaces].is_true).to include(product_one)
+      }
+      it {
+        expect(subject.fields[:custom_fields][:has_shoelaces].is_true).to_not include(product_two)
+      }
+    end
+
+    context "is_false" do
+      it {
+        expect(subject.fields[:custom_fields][:has_shoelaces].is_false).to include(product_two)
+      }
+      it {
+        expect(subject.fields[:custom_fields][:has_shoelaces].is_false).to_not include(product_one)
+      }
+    end
+
+    context "is_nil" do
+      it {
+        expect(subject.fields[:custom_fields][:has_shoelaces].is_nil).to_not include(product_one, product_two)
+      }
+    end
+  end
 
   context "enum" do
     context "eq" do

--- a/trax_model.gemspec
+++ b/trax_model.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "trax_core", "~> 0.0.83"
   spec.add_dependency "default_value_for", "~> 3.0.0"
-  spec.add_development_dependency "hashie", ">= 3.4.2"
+  spec.add_development_dependency "hashie", ">= 3.4.4"
   spec.add_development_dependency "rails", "~> 4.2.0"
   spec.add_development_dependency "activerecord", "~> 4.2.0"
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/trax_model.gemspec
+++ b/trax_model.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "trax_core", "~> 0.0.83"
+  spec.add_dependency "trax_core", "~> 0.0.84"
   spec.add_dependency "default_value_for", "~> 3.0.0"
-  spec.add_development_dependency "hashie", ">= 3.4.4"
+  # spec.add_development_dependency "hashie", ">= 3.4.4"
   spec.add_development_dependency "rails", "~> 4.2.0"
   spec.add_development_dependency "activerecord", "~> 4.2.0"
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
This begins adding support for a more flexible search scope syntax for attribute fields. Now, each field type has it's own set of scopes which make sense for that attribute, which can be used within other scopes in the main model class.