### PR TITLE
Fix defined attribute of struct with `:model_accessors => true` to work with `respond_to?`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
 require "bundler/gem_tasks"
-

--- a/lib/trax/model/attributes/dsl.rb
+++ b/lib/trax/model/attributes/dsl.rb
@@ -13,18 +13,6 @@ module Trax
             self.instance_variable_set("@_attribute_definitions_block", block)
           end
 
-          ##recursively search direct parent classes for attribute definitions, so we can fully support
-          ##inheritance
-          #def fetch_attribute_definitions_in_chain(_attribute_definitions_blocks = [], klass=nil)
-            #_attribute_definitions_blocks.push(klass.instance_variable_get("@_attribute_definitions_block")) if klass && klass.instance_variable_defined?("@_attribute_definitions_block")
-
-            #if klass && klass.superclass != ::ActiveRecord::Base
-              #return fetch_attribute_definitions_in_chain(_attribute_definitions_blocks, klass.superclass)
-            #else
-              #return _attribute_definitions_blocks.compact
-            #end
-          #end
-
           def fields_module
             @fields_module ||= begin
               module_name = "#{self.name}::Fields"

--- a/lib/trax/model/attributes/dsl.rb
+++ b/lib/trax/model/attributes/dsl.rb
@@ -13,17 +13,17 @@ module Trax
             self.instance_variable_set("@_attribute_definitions_block", block)
           end
 
-          #recursively search direct parent classes for attribute definitions, so we can fully support
-          #inheritance
-          def fetch_attribute_definitions_in_chain(_attribute_definitions_blocks = [], klass=nil)
-            _attribute_definitions_blocks.push(klass.instance_variable_get("@_attribute_definitions_block")) if klass && klass.instance_variable_defined?("@_attribute_definitions_block")
+          ##recursively search direct parent classes for attribute definitions, so we can fully support
+          ##inheritance
+          #def fetch_attribute_definitions_in_chain(_attribute_definitions_blocks = [], klass=nil)
+            #_attribute_definitions_blocks.push(klass.instance_variable_get("@_attribute_definitions_block")) if klass && klass.instance_variable_defined?("@_attribute_definitions_block")
 
-            if klass && klass.superclass != ::ActiveRecord::Base
-              return fetch_attribute_definitions_in_chain(_attribute_definitions_blocks, klass.superclass)
-            else
-              return _attribute_definitions_blocks.compact
-            end
-          end
+            #if klass && klass.superclass != ::ActiveRecord::Base
+              #return fetch_attribute_definitions_in_chain(_attribute_definitions_blocks, klass.superclass)
+            #else
+              #return _attribute_definitions_blocks.compact
+            #end
+          #end
 
           def fields_module
             @fields_module ||= begin

--- a/lib/trax/model/attributes/types/string.rb
+++ b/lib/trax/model/attributes/types/string.rb
@@ -17,7 +17,7 @@ module Trax
 
           class Value < ::Trax::Model::Attributes::Value
             include ::Trax::Model::ExtensionsFor::String
-            
+
             def self.type; :string end;
           end
 

--- a/lib/trax/model/attributes/types/struct.rb
+++ b/lib/trax/model/attributes/types/struct.rb
@@ -82,8 +82,6 @@ module Trax
               end
 
               model.delegate(getter_method, :to => attribute_name)
-
-              model.attribute_names << _property.to_s unless model.attribute_names.include?(_property.to_s)
             end
           end
         end

--- a/spec/db/schema/default_tables.rb
+++ b/spec/db/schema/default_tables.rb
@@ -89,4 +89,13 @@ DEFAULT_TABLES = Proc.new do
     t.datetime "created_at",        :null => false
     t.datetime "updated_at",        :null => false
   end
+
+  create_table "animals", :force => true do |t|
+    t.string "name"
+    t.string "uuid"
+    t.string "type"
+    t.string "characteristics" # `string` is a workaround for lack of jsonb support in sqlite
+    t.datetime "created_at",        :null => false
+    t.datetime "updated_at",        :null => false
+  end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -218,19 +218,14 @@ end
 class Animal < ::ActiveRecord::Base
   include ::Trax::Model
   include ::Trax::Model::Attributes::Dsl
-
-  define_attributes do
-    struct :characteristics, :model_accessors => true do
-      boolean :is_edible
-    end
-  end
-
-  validates_presence_of :type
 end
 
 class Mammal < ::Animal
+  include ::Trax::Model
+  include ::Trax::Model::Attributes::Dsl
+
   define_attributes do
-    struct :characteristics, :extends => "Animal::Fields::Characteristics", :model_accessors => true do
+    struct :characteristics, :model_accessors => true do
       string :fun_facts
     end
   end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -214,3 +214,24 @@ class User < ::ActiveRecord::Base
     end
   end
 end
+
+class Animal < ::ActiveRecord::Base
+  include ::Trax::Model
+  include ::Trax::Model::Attributes::Dsl
+
+  define_attributes do
+    struct :characteristics, :model_accessors => true do
+      boolean :is_edible
+    end
+  end
+
+  validates_presence_of :type
+end
+
+class Mammal < ::Animal
+  define_attributes do
+    struct :characteristics, :extends => "Animal::Fields::Characteristics", :model_accessors => true do
+      string :fun_facts
+    end
+  end
+end

--- a/spec/trax/model_spec.rb
+++ b/spec/trax/model_spec.rb
@@ -7,21 +7,24 @@ describe ::Trax::Model do
   it { subject.unique_id_config.uuid_prefix }
 
   context "with model accessors for struct attribute" do
-    context "inheriting model" do
-      let(:name) { "platypus" }
-      let(:fun_facts) { ["is most like edible"] }
-      let(:characteristics) { {:fun_facts => fun_facts} }
-      subject { ::Mammal.create!(:name => name, :characteristics => characteristics) }
+    let(:name) { "platypus" }
+    subject { ::Animal.new(:name => name) }
 
-      it { expect(::Animal.fields.constants).to_not include(:Characteristics) }
+    it { expect(::Animal.fields.constants).to_not include(:Characteristics) }
+
+    context "inheriting model" do
+      let(:fun_facts) { "is most like edible" }
+      let(:characteristics) { {:fun_facts => fun_facts} }
+      subject { ::Mammal.new(:name => name, :characteristics => characteristics) }
+
       it { expect(::Mammal.fields.constants).to include(:Characteristics) }
 
-      its(:"characteristics.fun_facts") { is_expected.to eq(fun_facts.to_json) }
+      its(:"characteristics.fun_facts") { is_expected.to eq(fun_facts) }
       it { expect(subject.characteristics.respond_to?(:fun_facts)).to eq(true) }
 
       context "model accessors" do
         its(:name) { is_expected.to eq(name) }
-        its(:fun_facts) { is_expected.to eq(fun_facts.to_json) }
+        its(:fun_facts) { is_expected.to eq(fun_facts) }
         it { expect(subject.respond_to?(:fun_facts)).to eq(true) }
       end
     end

--- a/spec/trax/model_spec.rb
+++ b/spec/trax/model_spec.rb
@@ -3,6 +3,28 @@ require 'spec_helper'
 describe ::Trax::Model do
   subject { ::Product }
 
-  its(:trax_registry_key) { should eq "product" }
+  its(:trax_registry_key) { is_expected.to eq "product" }
   it { subject.unique_id_config.uuid_prefix }
+
+  context "with model accessors for struct attribute" do
+    it { expect(::Animal.fields.constants).to include(:Characteristics) }
+
+    context "inheriting model" do
+      let(:name) { "platypus" }
+      let(:fun_facts) { ["is most like edible"] }
+      let(:characteristics) { {:fun_facts => fun_facts} }
+      subject { ::Mammal.create!(:name => name, :characteristics => characteristics) }
+
+      it { expect(::Mammal.fields.constants).to include(:Characteristics) }
+
+      #its(:name) { is_expected.to eq(name) }
+      #its(:fun_facts) { is_expected.to eq(fun_facts) }
+      #its(:characteristics) { is_expected.to eq(characteristics) }
+      #it { expect(subject.respond_to?(:fun_facts)).to eq(true) }
+
+      #its(:"characteristics.fun_facts") { is_expected.to eq(fun_facts) }
+      #it { expect(subject.characteristics.respond_to?(:fun_facts)).to eq(true) }
+      #it { binding.pry }
+    end
+  end
 end

--- a/spec/trax/model_spec.rb
+++ b/spec/trax/model_spec.rb
@@ -7,24 +7,23 @@ describe ::Trax::Model do
   it { subject.unique_id_config.uuid_prefix }
 
   context "with model accessors for struct attribute" do
-    it { expect(::Animal.fields.constants).to include(:Characteristics) }
-
     context "inheriting model" do
       let(:name) { "platypus" }
       let(:fun_facts) { ["is most like edible"] }
       let(:characteristics) { {:fun_facts => fun_facts} }
       subject { ::Mammal.create!(:name => name, :characteristics => characteristics) }
 
+      it { expect(::Animal.fields.constants).to_not include(:Characteristics) }
       it { expect(::Mammal.fields.constants).to include(:Characteristics) }
 
-      #its(:name) { is_expected.to eq(name) }
-      #its(:fun_facts) { is_expected.to eq(fun_facts) }
-      #its(:characteristics) { is_expected.to eq(characteristics) }
-      #it { expect(subject.respond_to?(:fun_facts)).to eq(true) }
+      its(:"characteristics.fun_facts") { is_expected.to eq(fun_facts.to_json) }
+      it { expect(subject.characteristics.respond_to?(:fun_facts)).to eq(true) }
 
-      #its(:"characteristics.fun_facts") { is_expected.to eq(fun_facts) }
-      #it { expect(subject.characteristics.respond_to?(:fun_facts)).to eq(true) }
-      #it { binding.pry }
+      context "model accessors" do
+        its(:name) { is_expected.to eq(name) }
+        its(:fun_facts) { is_expected.to eq(fun_facts.to_json) }
+        it { expect(subject.respond_to?(:fun_facts)).to eq(true) }
+      end
     end
   end
 end


### PR DESCRIPTION
This makes it so that model accessors defined through `define_attributes`'s `struct` DSL will property report as responding to a method name.

ActiveRecord overrides the OOTB version of `respond_to?` and does additional checks (which was returning false) if it happens to be listed under that model class's `column_names`. Consequently, `respond_to?` was not working properly since `column_names` were getting modified when structs were defined.

Went the route of *not* modifying the list of names, since attributes defined in the struct `define_attributes` block aren't real columns in the model's table.