### PR TITLE
Enumerable length query

### DIFF
--- a/lib/trax/model.rb
+++ b/lib/trax/model.rb
@@ -29,6 +29,7 @@ module Trax
     autoload :CoreExtensions
     autoload :ExtensionsFor
     autoload :Errors
+    autoload :RelationMethods
     autoload :Registry
     autoload :UUID
     autoload :UUIDArray

--- a/lib/trax/model/attributes/types/enum.rb
+++ b/lib/trax/model/attributes/types/enum.rb
@@ -15,6 +15,8 @@ module Trax
               ::Trax::Core::NamedClass.new(klass_name, ::Trax::Core::Types::Enum, :parent_definition => klass, &block)
             end
 
+            attribute_klass.include(::Trax::Model::ExtensionsFor::Enum)
+
             klass.attribute(attribute_name, ::Trax::Model::Attributes::Types::Enum::TypeCaster.new(target_klass: attribute_klass))
             klass.default_value_for(attribute_name) { options[:default] } if options.key?(:default)
             define_scopes(klass, attribute_name, attribute_klass) unless options.key?(:define_scopes) && !options[:define_scopes]

--- a/lib/trax/model/base.rb
+++ b/lib/trax/model/base.rb
@@ -3,6 +3,10 @@ module Trax
     module Base
       extend ::ActiveSupport::Concern
 
+      included do
+        self::ActiveRecord_Relation.include(::Trax::Model::RelationMethods)
+      end
+
       def dig(*args)
         try_chain(*args)
       end

--- a/lib/trax/model/extensions_for.rb
+++ b/lib/trax/model/extensions_for.rb
@@ -6,6 +6,7 @@ module Trax
 
       autoload :Base
       autoload :Boolean
+      autoload :Enum
       autoload :Enumerable
       autoload :Integer
       autoload :Numeric

--- a/lib/trax/model/extensions_for/enum.rb
+++ b/lib/trax/model/extensions_for/enum.rb
@@ -1,0 +1,22 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module Enum
+        extend ::ActiveSupport::Concern
+        include ::Trax::Model::ExtensionsFor::Base
+
+        module ClassMethods
+          def eq(_scope_value)
+            model_class.where({field_name => new(_scope_value)})
+          end
+
+          def in(*_scope_values)
+            _integer_values = select_values(*_scope_values.flat_compact_uniq!)
+            _integer_values.map!(&:to_s)
+            model_class.where({field_name => _integer_values})
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/enumerable.rb
+++ b/lib/trax/model/extensions_for/enumerable.rb
@@ -11,6 +11,26 @@ module Trax
             _values.flat_compact_uniq!
             model_class.where("#{field_name} ?| array[:values]", :values => _values)
           end
+
+          def length_eq(value)
+            model_class.where("JSONB_ARRAY_LENGTH(#{field_name}) = ?", value)
+          end
+
+          def length_gt(value)
+            model_class.where("JSONB_ARRAY_LENGTH(#{field_name}) > ?", value)
+          end
+
+          def length_lt(value)
+            model_class.where("JSONB_ARRAY_LENGTH(#{field_name}) < ?", value)
+          end
+
+          def length_gte(value)
+            model_class.where("JSONB_ARRAY_LENGTH(#{field_name}) >= ?", value)
+          end
+
+          def length_lte(value)
+            model_class.where("JSONB_ARRAY_LENGTH(#{field_name}) <= ?", value)
+          end
         end
       end
     end

--- a/lib/trax/model/relation_methods.rb
+++ b/lib/trax/model/relation_methods.rb
@@ -1,0 +1,11 @@
+module Trax
+  module Model
+    module RelationMethods
+      extend ::ActiveSupport::Concern
+
+      def fields
+        self.parent.fields
+      end
+    end
+  end
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -62,6 +62,14 @@ module Products
       end
 
       integer :in_stock_quantity, :default => 0
+
+      scope :by_above_average_size, lambda{
+        fields[:size].in(:mens_10, :mens_11, :mens_12)
+      }
+
+      scope :by_quantity_in_stock, lambda{ |value|
+        fields[:in_stock_quantity].eq(value)
+      }
     end
   end
 end

--- a/spec/trax/model/attributes/types/enum_spec.rb
+++ b/spec/trax/model/attributes/types/enum_spec.rb
@@ -29,6 +29,9 @@ describe ::Trax::Model::Attributes::Types::Enum do
 
       it { expect(subject.by_size(:mens_6, :mens_7)).to include(mens_6, mens_7) }
       it { expect(subject.by_size(:mens_6, :mens_7)).to_not include(mens_10) }
+      it { expect(subject.fields[:size].eq(:mens_6)).to include(mens_6) }
+      it { expect(subject.fields[:size].in(:mens_6)).to include(mens_6) }
+      it { expect(subject.fields[:size].in(:mens_6, :mens_7)).to include(mens_6, mens_7) }
     end
 
     context "dirty attributes" do

--- a/spec/trax/model/attributes/types/enum_spec.rb
+++ b/spec/trax/model/attributes/types/enum_spec.rb
@@ -19,9 +19,9 @@ describe ::Trax::Model::Attributes::Types::Enum do
     end
 
     context "search scopes" do
-      [ :mens_6, :mens_7, :mens_10 ].each_with_index do |enum_name|
+      [ :mens_6, :mens_7, :mens_10 ].each_with_index do |enum_name,i|
         let!(enum_name) do
-          ::Products::MensShoes.create(:size => enum_name)
+          ::Products::MensShoes.create(:size => enum_name, :in_stock_quantity => i)
         end
       end
 
@@ -32,6 +32,7 @@ describe ::Trax::Model::Attributes::Types::Enum do
       it { expect(subject.fields[:size].eq(:mens_6)).to include(mens_6) }
       it { expect(subject.fields[:size].in(:mens_6)).to include(mens_6) }
       it { expect(subject.fields[:size].in(:mens_6, :mens_7)).to include(mens_6, mens_7) }
+      it { expect(subject.by_above_average_size.by_quantity_in_stock(2)).to include(mens_10) }
     end
 
     context "dirty attributes" do

--- a/spec/trax/model/attributes/types/set_spec.rb
+++ b/spec/trax/model/attributes/types/set_spec.rb
@@ -51,7 +51,7 @@ describe ::Trax::Model::Attributes::Types::Set, :postgres => true do
       ::Ecommerce::Vote.create(:upvoter_ids => ['1', '2'], :downvoter_ids => ['3', '4', '5'] )
     }
     let!(:record_two) {
-      ::Ecommerce::Vote.create(:upvoter_ids => ['3', '4'], :downvoter_ids => ['6', '7', '8'] )
+      ::Ecommerce::Vote.create(:upvoter_ids => ['3', '4', '9'], :downvoter_ids => ['6', '7', '8', '20'] )
     }
     it {
       expect(
@@ -73,5 +73,31 @@ describe ::Trax::Model::Attributes::Types::Set, :postgres => true do
         ::Ecommerce::Vote::Fields::UpvoterIds.contains("4")
       ).to_not include record_one
     }
+
+    context "length methods" do
+      subject { ::Ecommerce::Vote::Fields::UpvoterIds }
+      context "length_eq" do
+        it { expect(subject.length_eq(2)).to include record_one }
+        it { expect(subject.length_eq(2)).to_not include record_two }
+      end
+
+      context "length_gt" do
+        it { expect(subject.length_gt(2)).to include record_two}
+        it { expect(subject.length_gt(2)).to_not include record_one }
+      end
+
+      context "length_lt" do
+        it { expect(subject.length_lt(3)).to include record_one}
+        it { expect(subject.length_lt(3)).to_not include record_two }
+      end
+
+      context "length_gte" do
+        it { expect(subject.length_gte(2)).to include(record_one, record_two) }
+      end
+
+      context "length_lte" do
+        it { expect(subject.length_lte(1)).to_not include(record_one, record_two) }
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds support for scoping field by an array's length (particularly useful for defining a behavior if it's empty or not)

i.e.
``` ruby
scope :with_related_ids, lambda{
  fields[:related_ids].length_gt(0)
}
```