### PR TITLE
flatten values before mapping values

### DIFF
--- a/lib/trax/model/mixins/field_scopes.rb
+++ b/lib/trax/model/mixins/field_scopes.rb
@@ -55,7 +55,7 @@ module Trax
               _relation = if _values.first.is_a?(::ActiveRecord::Relation)
                 where(_query, _values.first)
               else
-                _values.map!(&:downcase)
+                _values.flat_compact_uniq!.map!(&:downcase)
                 where(_query, _values)
               end
 


### PR DESCRIPTION
Fix to allow for an array to be passed into the field scope.