### PR TITLE
Fix array type use jsonb like set

### DIFF
--- a/lib/trax/model/attributes/definitions.rb
+++ b/lib/trax/model/attributes/definitions.rb
@@ -14,6 +14,10 @@ module Trax
           @model.trax_attribute(*args, type: type, **options, &block)
         end
 
+        def array(*args, **options, &block)
+          attribute(*args, :type => :array, **options, &block)
+        end
+
         def boolean(*args, **options, &block)
           attribute(*args, :type => :boolean, **options, &block)
         end

--- a/lib/trax/model/extensions_for.rb
+++ b/lib/trax/model/extensions_for.rb
@@ -4,6 +4,7 @@ module Trax
     module ExtensionsFor
       extend ::ActiveSupport::Autoload
 
+      autoload :Array
       autoload :Base
       autoload :Boolean
       autoload :Enum

--- a/lib/trax/model/extensions_for/array.rb
+++ b/lib/trax/model/extensions_for/array.rb
@@ -1,0 +1,16 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module Array
+        extend ::ActiveSupport::Concern
+        include ::Trax::Model::ExtensionsFor::Enumerable
+
+        module ClassMethods
+          def type
+            :array
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields.rb
+++ b/lib/trax/model/extensions_for/struct_fields.rb
@@ -4,11 +4,14 @@ module Trax
       module StructFields
         extend ::ActiveSupport::Autoload
 
+        autoload :Array
         autoload :Boolean
         autoload :Enum
+        autoload :Enumerable
         autoload :Float
         autoload :Integer
         autoload :Numeric
+        autoload :Set
         autoload :String
         autoload :Time
 

--- a/lib/trax/model/extensions_for/struct_fields/array.rb
+++ b/lib/trax/model/extensions_for/struct_fields/array.rb
@@ -1,0 +1,12 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Array
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::StructFields::Enumerable
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/enumerable.rb
+++ b/lib/trax/model/extensions_for/struct_fields/enumerable.rb
@@ -1,0 +1,44 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Enumerable
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::Base
+
+          module ClassMethods
+            def contains(*_values)
+              _values.flat_compact_uniq!
+              model_class.where("(#{parent_definition.field_name} -> '#{field_name}' ?| array[:values])", :values => _values)
+            end
+
+            def does_not_contain(*_values)
+              _values.flat_compact_uniq!
+              model_class.where.not("(#{parent_definition.field_name} -> '#{field_name}' ?| array[:values])", :values => _values)
+            end
+
+            def length_eq(value)
+              model_class.where("(JSONB_ARRAY_LENGTH(#{parent_definition.field_name} -> '#{field_name}') = ?)", value)
+            end
+
+            def length_gt(value)
+              model_class.where("(JSONB_ARRAY_LENGTH(#{parent_definition.field_name} -> '#{field_name}') > ?)", value)
+            end
+
+            def length_lt(value)
+              model_class.where("(JSONB_ARRAY_LENGTH(#{parent_definition.field_name} -> '#{field_name}') < ?)", value)
+            end
+
+            def length_gte(value)
+              model_class.where("(JSONB_ARRAY_LENGTH(#{parent_definition.field_name} -> '#{field_name}') >= ?)", value)
+            end
+
+            def length_lte(value)
+              model_class.where("(JSONB_ARRAY_LENGTH(#{parent_definition.field_name} -> '#{field_name}') <= ?)", value)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/extensions_for/struct_fields/set.rb
+++ b/lib/trax/model/extensions_for/struct_fields/set.rb
@@ -1,0 +1,12 @@
+module Trax
+  module Model
+    module ExtensionsFor
+      module StructFields
+        module Set
+          extend ::ActiveSupport::Concern
+          include ::Trax::Model::ExtensionsFor::StructFields::Enumerable
+        end
+      end
+    end
+  end
+end

--- a/spec/db/schema/pg_tables.rb
+++ b/spec/db/schema/pg_tables.rb
@@ -21,6 +21,8 @@ PG_TABLES = Proc.new do
     t.uuid "voteable_id"
     t.jsonb "upvoter_ids"
     t.jsonb "downvoter_ids"
+    t.jsonb "upvoter_ids_array"
+    t.jsonb "downvoter_ids_array"
     t.datetime "created_at",        :null => false
     t.datetime "updated_at",        :null => false
   end

--- a/spec/support/pg/models.rb
+++ b/spec/support/pg/models.rb
@@ -62,6 +62,8 @@ module Ecommerce
     define_attributes do
       set :upvoter_ids
       set :downvoter_ids
+      array :upvoter_ids_array
+      array :downvoter_ids_array
     end
   end
 

--- a/spec/trax/model/attributes/types/array_spec.rb
+++ b/spec/trax/model/attributes/types/array_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe ::Trax::Model::Attributes::Types::Array, :postgres => true do
   subject{ ::Ecommerce::Vote.new(:upvoter_ids_array => ["1", "2"], :downvoter_ids_array => ["3", "4", "5"] )}
 
-  it { expect(subject.upvoter_ids.__getobj__).to be_a(::Array) }
-  it { expect(subject.upvoter_ids).to include("1") }
+  it { expect(subject.upvoter_ids_array.__getobj__).to be_a(::Array) }
+  it { expect(subject.upvoter_ids_array).to include("1") }
 
   context "attribute definition" do
     subject { ::Ecommerce::Vote::Fields::UpvoterIdsArray.new }
@@ -19,26 +19,26 @@ describe ::Trax::Model::Attributes::Types::Array, :postgres => true do
     }
   end
 
-  context "does not allow duplicate values" do
+  context "does allow duplicate values" do
     it {
       subject.upvoter_ids_array << "1"
-      expect(subject.upvoter_ids_array.length).to eq 2
+      expect(subject.upvoter_ids_array.length).to eq 3
     }
   end
 
   context "dirty tracking" do
     it {
       subject.save
-      subject.upvoter_ids = ["2","3"]
-      expect(subject.upvoter_ids_was).to eq ::Array.new(["1","2"])
+      subject.upvoter_ids_array = ["2","3"]
+      expect(subject.upvoter_ids_array_was).to eq ::Array.new(["1","2"])
     }
   end
 
   context "setting value" do
-    context "already a set" do
+    context "already an array" do
       let(:val) { ::Ecommerce::Vote::Fields::UpvoterIdsArray.new(["1", "2"]) }
       subject { ::Ecommerce::Vote.new(:upvoter_ids_array => val) }
-      it { expect(subject.upvoter_ids_array).to eq ::Set.new(["1","2"]) }
+      it { expect(subject.upvoter_ids_array).to eq ["1","2"] }
       it { expect(subject.upvoter_ids_array).to be_a(::Ecommerce::Vote::Fields::UpvoterIdsArray) }
     end
   end
@@ -48,10 +48,10 @@ describe ::Trax::Model::Attributes::Types::Array, :postgres => true do
   #I.e. define a scope on the model, by referencing the field directly.
   context "relations" do
     let!(:record_one) {
-      ::Ecommerce::Vote.create(:upvoter_ids => ['1', '2'], :downvoter_ids => ['3', '4', '5'] )
+      ::Ecommerce::Vote.create(:upvoter_ids_array => ['1', '2'], :downvoter_ids_array => ['3', '4', '5'] )
     }
     let!(:record_two) {
-      ::Ecommerce::Vote.create(:upvoter_ids => ['3', '4', '9'], :downvoter_ids => ['6', '7', '8', '20'] )
+      ::Ecommerce::Vote.create(:upvoter_ids_array => ['3', '4', '9'], :downvoter_ids_array => ['6', '7', '8', '20'] )
     }
     it {
       expect(

--- a/spec/trax/model/attributes/types/array_spec.rb
+++ b/spec/trax/model/attributes/types/array_spec.rb
@@ -23,6 +23,7 @@ describe ::Trax::Model::Attributes::Types::Array, :postgres => true do
     it {
       subject.upvoter_ids_array << "1"
       expect(subject.upvoter_ids_array.length).to eq 3
+      expect(subject.upvoter_ids_array.select{|v| v == "1"}.length).to eq 2
     }
   end
 

--- a/spec/trax/model/attributes/types/array_spec.rb
+++ b/spec/trax/model/attributes/types/array_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe ::Trax::Model::Attributes::Types::Array, :postgres => true do
+  subject{ ::Ecommerce::Vote.new(:upvoter_ids_array => ["1", "2"], :downvoter_ids_array => ["3", "4", "5"] )}
+
+  it { expect(subject.upvoter_ids.__getobj__).to be_a(::Array) }
+  it { expect(subject.upvoter_ids).to include("1") }
+
+  context "attribute definition" do
+    subject { ::Ecommerce::Vote::Fields::UpvoterIdsArray.new }
+    it { expect(subject.__getobj__).to be_a(::Array) }
+  end
+
+  context "loading from database" do
+    it {
+      subject.save
+      test_subject = subject.reload
+      expect(test_subject.upvoter_ids_array).to include("1")
+    }
+  end
+
+  context "does not allow duplicate values" do
+    it {
+      subject.upvoter_ids_array << "1"
+      expect(subject.upvoter_ids_array.length).to eq 2
+    }
+  end
+
+  context "dirty tracking" do
+    it {
+      subject.save
+      subject.upvoter_ids = ["2","3"]
+      expect(subject.upvoter_ids_was).to eq ::Array.new(["1","2"])
+    }
+  end
+
+  context "setting value" do
+    context "already a set" do
+      let(:val) { ::Ecommerce::Vote::Fields::UpvoterIdsArray.new(["1", "2"]) }
+      subject { ::Ecommerce::Vote.new(:upvoter_ids_array => val) }
+      it { expect(subject.upvoter_ids_array).to eq ::Set.new(["1","2"]) }
+      it { expect(subject.upvoter_ids_array).to be_a(::Ecommerce::Vote::Fields::UpvoterIdsArray) }
+    end
+  end
+
+  #note: only supports string values for scopes at the moment
+  #also note: I think this is the ideal api for the future.
+  #I.e. define a scope on the model, by referencing the field directly.
+  context "relations" do
+    let!(:record_one) {
+      ::Ecommerce::Vote.create(:upvoter_ids => ['1', '2'], :downvoter_ids => ['3', '4', '5'] )
+    }
+    let!(:record_two) {
+      ::Ecommerce::Vote.create(:upvoter_ids => ['3', '4', '9'], :downvoter_ids => ['6', '7', '8', '20'] )
+    }
+    it {
+      expect(
+        ::Ecommerce::Vote::Fields::UpvoterIdsArray.contains("1")
+      ).to include record_one
+    }
+    it {
+      expect(
+        ::Ecommerce::Vote::Fields::UpvoterIdsArray.does_not_contain("1")
+      ).to_not include record_one
+    }
+    it {
+      expect(
+        ::Ecommerce::Vote::Fields::UpvoterIdsArray.contains("1")
+      ).to_not include record_two
+    }
+    it {
+      expect(
+        ::Ecommerce::Vote::Fields::UpvoterIdsArray.contains("4")
+      ).to include record_two
+    }
+    it {
+      expect(
+        ::Ecommerce::Vote::Fields::UpvoterIdsArray.contains("4")
+      ).to_not include record_one
+    }
+
+    context "length methods" do
+      subject { ::Ecommerce::Vote::Fields::UpvoterIdsArray }
+      context "length_eq" do
+        it { expect(subject.length_eq(2)).to include record_one }
+        it { expect(subject.length_eq(2)).to_not include record_two }
+      end
+
+      context "length_gt" do
+        it { expect(subject.length_gt(2)).to include record_two}
+        it { expect(subject.length_gt(2)).to_not include record_one }
+      end
+
+      context "length_lt" do
+        it { expect(subject.length_lt(3)).to include record_one}
+        it { expect(subject.length_lt(3)).to_not include record_two }
+      end
+
+      context "length_gte" do
+        it { expect(subject.length_gte(2)).to include(record_one, record_two) }
+      end
+
+      context "length_lte" do
+        it { expect(subject.length_lte(1)).to_not include(record_one, record_two) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Makes array type work again. Expects array columns to be defined as JSONB just like set attributes do. (so the array gets stored as a json array). Doing so allows us to share the same code and keeps things consistent.
