### PR TITLE
Fix cache key expiration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'hashie', :github => "jasonayre/hashie"
-# gem 'trax_core', :github => "jasonayre/trax_core"
+gem 'trax_core', :github => "jasonayre/trax_core"
 # gem 'trax_core', :path => "~/gems/trax_core"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'hashie', :github => "jasonayre/hashie"
-gem 'trax_core', :github => "jasonayre/trax_core"
+# gem 'trax_core', :github => "jasonayre/trax_core"
 # gem 'trax_core', :path => "~/gems/trax_core"
 
 gemspec

--- a/lib/trax/model.rb
+++ b/lib/trax/model.rb
@@ -24,6 +24,7 @@ module Trax
     autoload :Attributes
     autoload :Base
     autoload :CacheKey
+    autoload :CacheStoreExtensions
     autoload :Config
     autoload :Concerns
     autoload :CoreExtensions
@@ -78,6 +79,7 @@ module Trax
     def self.cache=(cache_store)
       ::Trax::Model.configure do |config|
         config.cache = cache_store
+        config.cache.singleton_class.include(::Trax::Model::CacheStoreExtensions)
       end
     end
 

--- a/lib/trax/model.rb
+++ b/lib/trax/model.rb
@@ -88,6 +88,7 @@ module Trax
 
     def self.eager_autoload_mixins!
       ::Trax::Model::Mixins::CachedFindBy
+      ::Trax::Model::Mixins::CachedMethods
       ::Trax::Model::Mixins::CachedRelations
       ::Trax::Model::Mixins::FieldScopes
       ::Trax::Model::Mixins::Freezable

--- a/lib/trax/model/cache_key.rb
+++ b/lib/trax/model/cache_key.rb
@@ -9,11 +9,15 @@ module Trax
         params.symbolize_keys!
         @options = params.extract!(*CACHE_OPTION_KEYS)
         @search_params = params
-        @obj = ::Set[*args.sort, params.sort].flatten.to_a
+        @obj = ::Set[*args.sort, params.sort].to_a.flatten
       end
 
       def __getobj__
         @obj
+      end
+
+      def to_s
+        @obj.join("/")
       end
     end
   end

--- a/lib/trax/model/cache_key.rb
+++ b/lib/trax/model/cache_key.rb
@@ -5,11 +5,21 @@ module Trax
 
       attr_reader :options, :search_params
 
-      def initialize(*args, **params)
+      def self.for_class_method(klass, method_name, *args, **options)
+        new("#{klass.name.underscore}.#{method_name}", *args, **options)
+      end
+
+      def self.for_instance_method(klass, method_name, *args, **options)
+        new("#{klass.name.underscore}##{method_name}", *args, **options)
+      end
+
+      def initialize(path_for_method, *args, **params)
+        @path_for_method = path_for_method
+        @arguments = args
         params.symbolize_keys!
         @options = params.extract!(*CACHE_OPTION_KEYS)
         @search_params = params
-        @obj = ::Set[*args.sort, params.sort].to_a.flatten
+        @obj = ::Set[@path_for_method, *args.map(&:to_s).sort, params.sort].to_a.flatten
       end
 
       def __getobj__
@@ -17,7 +27,7 @@ module Trax
       end
 
       def to_s
-        @obj.join("/")
+        @obj.join('/')
       end
     end
   end

--- a/lib/trax/model/cache_store_extensions.rb
+++ b/lib/trax/model/cache_store_extensions.rb
@@ -1,6 +1,11 @@
 module Trax
   module Model
     module CacheStoreExtensions
+      def self.extend_cache_store(cache_store)
+        cache_store.singleton_class.include(::Trax::Model::CacheStoreExtensions)
+        cache_store
+      end
+
       def fetch(*args, **options)
         if(args.first.is_a?(::Trax::Model::CacheKey))
           cache_key = args.first

--- a/lib/trax/model/cache_store_extensions.rb
+++ b/lib/trax/model/cache_store_extensions.rb
@@ -1,0 +1,14 @@
+module Trax
+  module Model
+    module CacheStoreExtensions
+      def fetch(*args, **options)
+        if(args.first.is_a?(::Trax::Model::CacheKey))
+          cache_key = args.first
+          super(cache_key, **cache_key.options)
+        else
+          super(*args, **options)
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/cache_store_extensions.rb
+++ b/lib/trax/model/cache_store_extensions.rb
@@ -6,7 +6,8 @@ module Trax
           cache_key = args.first
           super(cache_key, **cache_key.options)
         else
-          super(*args, **options)
+          cache_key = ::Trax::Model::CacheKey.new(*args, **options)
+          super(cache_key, **cache_key.options)
         end
       end
     end

--- a/lib/trax/model/mixins.rb
+++ b/lib/trax/model/mixins.rb
@@ -4,6 +4,7 @@ module Trax
       extend ::ActiveSupport::Autoload
 
       autoload :CachedFindBy
+      autoload :CachedMethods
       autoload :CachedRelations
       autoload :FieldScopes
       autoload :Freezable

--- a/lib/trax/model/mixins/cached_methods.rb
+++ b/lib/trax/model/mixins/cached_methods.rb
@@ -7,6 +7,7 @@ module Trax
         module ClassMethods
           def cached_class_method(method_name, as:nil, **config_options)
             cached_method_name = as || "cached_#{method_name}"
+            cache_clearer_method_name = "clear_#{cached_method_name}"
 
             define_singleton_method(cached_method_name) do |*args, **options|
               method_cache_key = ::Trax::Model::CacheKey.for_class_method(self, method_name, *args, **config_options.merge(options))
@@ -15,10 +16,17 @@ module Trax
                 __smartsend__(method_name, *args, **options)
               end
             end
+
+            define_singleton_method(cache_clearer_method_name) do |*args, **options|
+              method_cache_key = ::Trax::Model::CacheKey.for_class_method(self, method_name, *args, **config_options.merge(options))
+
+              ::Trax::Model.cache.delete(method_cache_key)
+            end
           end
 
           def cached_instance_method(method_name, as:nil, **config_options)
             cached_method_name = as || "cached_#{method_name}"
+            cache_clearer_method_name = "clear_#{cached_method_name}"
 
             define_method(cached_method_name) do |*args, **options|
               method_cache_key = ::Trax::Model::CacheKey.for_instance_method(self.class, method_name, self.id, *args, **config_options.merge(options))
@@ -26,6 +34,12 @@ module Trax
               ::Trax::Model.cache.fetch(method_cache_key) do
                 __smartsend__(method_name, *args, **options)
               end
+            end
+
+            define_method(cache_clearer_method_name) do |*args, **options|
+              method_cache_key = ::Trax::Model::CacheKey.for_instance_method(self.class, method_name, self.id, *args, **config_options.merge(options))
+
+              ::Trax::Model.cache.delete(method_cache_key)
             end
           end
         end

--- a/lib/trax/model/mixins/cached_methods.rb
+++ b/lib/trax/model/mixins/cached_methods.rb
@@ -8,15 +8,15 @@ module Trax
           def cached_class_method(method_name, **config_options)
             define_singleton_method("cached_#{method_name}") do |*args, **options|
               method_cache_key = ::Trax::Model::CacheKey.for_class_method(self, method_name, *args, **config_options.merge(options))
-              has_args = method(method_name).arity != 0
-              has_options = method(method_name).parameters.any?
+              accepts_args = method(method_name).arity != 0
+              has_options = !options.empty?
 
               ::Trax::Model.cache.fetch(method_cache_key) do
-                result = if !has_args && !has_options
+                result = if !accepts_args && !has_options
                   __send__(method_name)
-                elsif has_args && has_options
+                elsif accepts_args && has_options
                   __send__(method_name, *args, **options)
-                elsif has_args
+                elsif accepts_args
                   __send__(method_name, *args)
                 elsif has_options
                   __send__(method_name, **options)
@@ -30,15 +30,15 @@ module Trax
           def cached_instance_method(method_name, **config_options)
             define_method("cached_#{method_name}") do |*args, **options|
               method_cache_key = ::Trax::Model::CacheKey.for_instance_method(self.class, method_name, *args, **config_options.merge(options))
-              has_args = method(method_name).arity != 0
+              accepts_args = method(method_name).arity != 0
               has_options = method(method_name).parameters.any?
 
               ::Trax::Model.cache.fetch(method_cache_key) do
-                result = if !has_args && !has_options
+                result = if !accepts_args && !has_options
                   __send__(method_name)
-                elsif has_args && has_options
+                elsif accepts_args && has_options
                   __send__(method_name, *args, **options)
-                elsif has_args
+                elsif accepts_args
                   __send__(method_name, *args)
                 elsif has_options
                   __send__(method_name, **options)

--- a/lib/trax/model/mixins/cached_methods.rb
+++ b/lib/trax/model/mixins/cached_methods.rb
@@ -5,8 +5,10 @@ module Trax
         extend ::Trax::Model::Mixin
 
         module ClassMethods
-          def cached_class_method(method_name, **config_options)
-            define_singleton_method("cached_#{method_name}") do |*args, **options|
+          def cached_class_method(method_name, as:nil, **config_options)
+            cached_method_name = as || "cached_#{method_name}"
+
+            define_singleton_method(cached_method_name) do |*args, **options|
               method_cache_key = ::Trax::Model::CacheKey.for_class_method(self, method_name, *args, **config_options.merge(options))
 
               ::Trax::Model.cache.fetch(method_cache_key) do
@@ -15,8 +17,10 @@ module Trax
             end
           end
 
-          def cached_instance_method(method_name, **config_options)
-            define_method("cached_#{method_name}") do |*args, **options|
+          def cached_instance_method(method_name, as:nil, **config_options)
+            cached_method_name = as || "cached_#{method_name}"
+
+            define_method(cached_method_name) do |*args, **options|
               method_cache_key = ::Trax::Model::CacheKey.for_instance_method(self.class, method_name, self.id, *args, **config_options.merge(options))
 
               ::Trax::Model.cache.fetch(method_cache_key) do

--- a/lib/trax/model/mixins/cached_methods.rb
+++ b/lib/trax/model/mixins/cached_methods.rb
@@ -11,9 +11,13 @@ module Trax
               accepts_args = method(method_name).arity != 0
               has_options = !options.empty?
 
+              binding.pry
+
               ::Trax::Model.cache.fetch(method_cache_key) do
-                result = if !accepts_args && !has_options
+                result = if !accepts_args
                   __send__(method_name)
+                elsif accepts_args
+                  __send__(method_name, *args, **options)
                 elsif accepts_args && has_options
                   __send__(method_name, *args, **options)
                 elsif accepts_args

--- a/lib/trax/model/mixins/cached_methods.rb
+++ b/lib/trax/model/mixins/cached_methods.rb
@@ -1,0 +1,55 @@
+module Trax
+  module Model
+    module Mixins
+      module CachedMethods
+        extend ::Trax::Model::Mixin
+
+        module ClassMethods
+          def cached_class_method(method_name, **config_options)
+            define_singleton_method("cached_#{method_name}") do |*args, **options|
+              method_cache_key = ::Trax::Model::CacheKey.for_class_method(self, method_name, *args, **config_options.merge(options))
+              has_args = method(method_name).arity != 0
+              has_options = method(method_name).parameters.any?
+
+              ::Trax::Model.cache.fetch(method_cache_key) do
+                result = if !has_args && !has_options
+                  __send__(method_name)
+                elsif has_args && has_options
+                  __send__(method_name, *args, **options)
+                elsif has_args
+                  __send__(method_name, *args)
+                elsif has_options
+                  __send__(method_name, **options)
+                end
+
+                result
+              end
+            end
+          end
+
+          def cached_instance_method(method_name, **config_options)
+            define_method("cached_#{method_name}") do |*args, **options|
+              method_cache_key = ::Trax::Model::CacheKey.for_instance_method(self.class, method_name, *args, **config_options.merge(options))
+              has_args = method(method_name).arity != 0
+              has_options = method(method_name).parameters.any?
+
+              ::Trax::Model.cache.fetch(method_cache_key) do
+                result = if !has_args && !has_options
+                  __send__(method_name)
+                elsif has_args && has_options
+                  __send__(method_name, *args, **options)
+                elsif has_args
+                  __send__(method_name, *args)
+                elsif has_options
+                  __send__(method_name, **options)
+                end
+
+                result
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trax/model/mixins/cached_methods.rb
+++ b/lib/trax/model/mixins/cached_methods.rb
@@ -8,47 +8,19 @@ module Trax
           def cached_class_method(method_name, **config_options)
             define_singleton_method("cached_#{method_name}") do |*args, **options|
               method_cache_key = ::Trax::Model::CacheKey.for_class_method(self, method_name, *args, **config_options.merge(options))
-              accepts_args = method(method_name).arity != 0
-              has_options = !options.empty?
-
-              binding.pry
 
               ::Trax::Model.cache.fetch(method_cache_key) do
-                result = if !accepts_args
-                  __send__(method_name)
-                elsif accepts_args
-                  __send__(method_name, *args, **options)
-                elsif accepts_args && has_options
-                  __send__(method_name, *args, **options)
-                elsif accepts_args
-                  __send__(method_name, *args)
-                elsif has_options
-                  __send__(method_name, **options)
-                end
-
-                result
+                __smartsend__(method_name, *args, **options)
               end
             end
           end
 
           def cached_instance_method(method_name, **config_options)
             define_method("cached_#{method_name}") do |*args, **options|
-              method_cache_key = ::Trax::Model::CacheKey.for_instance_method(self.class, method_name, *args, **config_options.merge(options))
-              accepts_args = method(method_name).arity != 0
-              has_options = method(method_name).parameters.any?
+              method_cache_key = ::Trax::Model::CacheKey.for_instance_method(self.class, method_name, self.id, *args, **config_options.merge(options))
 
               ::Trax::Model.cache.fetch(method_cache_key) do
-                result = if !accepts_args && !has_options
-                  __send__(method_name)
-                elsif accepts_args && has_options
-                  __send__(method_name, *args, **options)
-                elsif accepts_args
-                  __send__(method_name, *args)
-                elsif has_options
-                  __send__(method_name, **options)
-                end
-
-                result
+                __smartsend__(method_name, *args, **options)
               end
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'bundler'
 require 'simplecov'
 # require 'pry'
 require 'trax_model'
+require 'timecop'
 require 'rails'
 require 'active_record'
 ::Rails.cache = ::ActiveSupport::Cache::MemoryStore.new

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -49,7 +49,7 @@ class Product < ::ActiveRecord::Base
   def some_cached_instance_method
     self.class.inventory_cost
   end
-  cached_instance_method(:some_cached_instance_method, :expires_in => 20.minutes)
+  cached_instance_method(:some_cached_instance_method, :as => :some_instance_method, :expires_in => 20.minutes)
 
   mixins :field_scopes => {
     :by_id => true

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -36,6 +36,21 @@ class Product < ::ActiveRecord::Base
   end
   cached_class_method(:in_stock_quantities, :expires_in => 20.minutes)
 
+  def self.in_stock_quantities_splat(*_ids)
+    by_id(*_ids).sum(:in_stock_quantity)
+  end
+  cached_class_method(:in_stock_quantities_splat, :expires_in => 20.minutes)
+
+  def self.in_stock_quantities_keywords(ids:[])
+    by_id(*ids).sum(:in_stock_quantity)
+  end
+  cached_class_method(:in_stock_quantities_keywords, :expires_in => 20.minutes)
+
+  def self.in_stock_quantities_too_many_params(_whatevers=[], something_else=nil, *args, ids:[])
+    by_id(*ids).sum(:in_stock_quantity)
+  end
+  # cached_class_method(:in_stock_quantities_keywords, :expires_in => 20.minutes)
+
   mixins :field_scopes => {
     :by_id => true
   }

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -27,7 +27,7 @@ class Product < ::ActiveRecord::Base
   sort_scope :in_stock_quantity, :as => :quantity_in_stock
   sort_scope :on_order_quantity, :as => :quantity_out_of_stock
 
-  class_attribute :inventory_cost
+  class_attribute :inventory_cost, :instance_writer => false
   self.inventory_cost = 0
   cached_class_method(:inventory_cost, :expires_in => 20.minutes)
 
@@ -46,10 +46,10 @@ class Product < ::ActiveRecord::Base
   end
   cached_class_method(:in_stock_quantities_keywords, :expires_in => 20.minutes)
 
-  def self.in_stock_quantities_too_many_params(_whatevers=[], something_else=nil, *args, ids:[])
-    by_id(*ids).sum(:in_stock_quantity)
+  def some_cached_instance_method
+    self.class.inventory_cost
   end
-  # cached_class_method(:in_stock_quantities_keywords, :expires_in => 20.minutes)
+  cached_instance_method(:some_cached_instance_method, :expires_in => 20.minutes)
 
   mixins :field_scopes => {
     :by_id => true

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -20,17 +20,30 @@ class Product < ::ActiveRecord::Base
   include ::Trax::Model::Attributes::Dsl
 
   mixins :unique_id => { :uuid_column => "uuid", :uuid_prefix => "1a" },
-         :sort_scopes => true
+         :sort_scopes => true,
+         :cached_methods => true
 
   sort_scope :name
   sort_scope :in_stock_quantity, :as => :quantity_in_stock
   sort_scope :on_order_quantity, :as => :quantity_out_of_stock
 
+  class_attribute :inventory_cost
+  self.inventory_cost = 0
+  cached_class_method(:inventory_cost, :expires_in => 20.minutes)
+
+  def self.in_stock_quantities(_ids=[])
+    by_id(*_ids).sum(:in_stock_quantity)
+  end
+  cached_class_method(:in_stock_quantities, :expires_in => 20.minutes)
+
+  mixins :field_scopes => {
+    :by_id => true
+  }
+
   belongs_to :category
 
   define_attributes do
     string :name
-
     integer :in_stock_quantity
     integer :on_order_quantity
 

--- a/spec/trax/model/attributes/fields_spec.rb
+++ b/spec/trax/model/attributes/fields_spec.rb
@@ -34,6 +34,7 @@ describe ::Trax::Model::Attributes::Fields do
       context "includes full choice definitions" do
         let(:expectation) do
           {
+            "attributes"=> {},
             "source"=>"Products::MensShoes::Fields::Status::InStock",
              "name"=>"in_stock",
              "type"=>:enum_value,

--- a/spec/trax/model/attributes/types/struct_spec.rb
+++ b/spec/trax/model/attributes/types/struct_spec.rb
@@ -4,7 +4,7 @@ describe ::Trax::Model::Attributes::Types::Struct, :postgres => true do
   subject{ ::Ecommerce::Products::MensShoes::Fields::CustomFields }
 
   it { expect(subject.new.primary_utility).to eq "Skateboarding" }
-  it { expect(subject.new.sole_material).to eq "" }
+  it { expect(subject.new.sole_material).to eq nil }
 
   context "attribute definition" do
     subject { ::Ecommerce::ShippingAttributes.new }

--- a/spec/trax/model/cache_key_spec.rb
+++ b/spec/trax/model/cache_key_spec.rb
@@ -1,27 +1,24 @@
 require 'spec_helper'
 
 describe ::Trax::Model::CacheKey do
-  subject{ described_class }
+  let(:fake_id) { 1 }
+  let(:expires) { 2.hours }
+  let(:cache_options) { {:expires_in => expires } }
+  let(:search_params) { {:id => fake_id} }
+  let(:cache_key_params) { cache_options.merge(search_params) }
+  subject{ described_class.new("posts", **cache_key_params) }
 
-  describe ".new" do
-    let(:fake_id) { 1 }
-    let(:expires) { 2.hours }
-    let(:cache_options) { {:expires_in => expires } }
-    let(:search_params) { {:id => fake_id} }
-    let(:cache_key_params) { cache_options.merge(search_params) }
-    subject { ::Trax::Model::CacheKey.new("posts", **cache_key_params) }
-    it { expect(subject.first).to eq "posts" }
-    it { expect(subject.options).to eq cache_options }
-    it { expect(subject.to_s).to eq "posts/id/1"}
+  it { expect(subject.first).to eq "posts" }
+  it { expect(subject.options).to eq cache_options }
+  it { expect(subject.to_s).to eq "posts/id/1" }
 
-    context "order of params" do
-      let(:search_params) { {:id => fake_id, :a => "b"} }
+  context "order of params" do
+    let(:search_params) { {:id => fake_id, :a => "b"} }
+    it { expect(subject.to_s).to eq "posts/a/b/id/1" }
+
+    context "does not matter" do
+      let(:search_params) { {:a => "b", :id => fake_id} }
       it { expect(subject.to_s).to eq "posts/a/b/id/1" }
-
-      context "does not matter" do
-        let(:search_params) { {:a => "b", :id => fake_id} }
-        it { expect(subject.to_s).to eq "posts/a/b/id/1" }
-      end
     end
   end
 end

--- a/spec/trax/model/cache_key_spec.rb
+++ b/spec/trax/model/cache_key_spec.rb
@@ -3,12 +3,25 @@ require 'spec_helper'
 describe ::Trax::Model::CacheKey do
   subject{ described_class }
 
-  context "cache key" do
+  describe ".new" do
     let(:fake_id) { 1 }
     let(:expires) { 2.hours }
     let(:cache_options) { {:expires_in => expires } }
-    subject { ::Trax::Model::CacheKey.new("posts", :id => fake_id, :expires_in => expires) }
+    let(:search_params) { {:id => fake_id} }
+    let(:cache_key_params) { cache_options.merge(search_params) }
+    subject { ::Trax::Model::CacheKey.new("posts", **cache_key_params) }
     it { expect(subject.first).to eq "posts" }
     it { expect(subject.options).to eq cache_options }
+    it { expect(subject.to_s).to eq "posts/id/1"}
+
+    context "order of params" do
+      let(:search_params) { {:id => fake_id, :a => "b"} }
+      it { expect(subject.to_s).to eq "posts/a/b/id/1" }
+
+      context "does not matter" do
+        let(:search_params) { {:a => "b", :id => fake_id} }
+        it { expect(subject.to_s).to eq "posts/a/b/id/1" }
+      end
+    end
   end
 end

--- a/spec/trax/model/cache_store_extensions_spec.rb
+++ b/spec/trax/model/cache_store_extensions_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe ::Trax::Model::CacheStoreExtensions do
+  before do
+    ::Trax::Model.cache = ::ActiveSupport::Cache::MemoryStore.new
+  end
+
+  subject{ ::Trax::Model.cache }
+
+  context "#fetch" do
+    let(:cache_key) { ::Trax::Model::CacheKey.new("posts", :expires_in => 2.seconds) }
+    it {
+      subject.fetch(cache_key) { "one" }
+      expect(subject.fetch(cache_key)).to eq "one"
+      sleep(2)
+      expect(subject.fetch(cache_key) { "two" }).to eq "two"
+    }
+  end
+end

--- a/spec/trax/model/mixins/cached_methods_spec.rb
+++ b/spec/trax/model/mixins/cached_methods_spec.rb
@@ -79,4 +79,24 @@ describe ::Trax::Model::Mixins::CachedMethods do
       }
     end
   end
+
+  context "cached instance methods" do
+    before { ::Product.inventory_cost = 0 }
+    subject {
+      ::Product.create(:name => "whatever")
+    }
+
+    let(:keys_in_cache) { ::Trax::Model.cache.instance_variable_get(:@data).keys }
+
+    it {
+      expect(subject.cached_some_cached_instance_method).to eq 0
+      expect(keys_in_cache).to include("product#some_cached_instance_method/#{subject.id}")
+      subject.class.inventory_cost = 20
+      expect(subject.cached_some_cached_instance_method).to eq 0
+
+      Timecop.freeze(Time.now + 30.minutes) do
+        expect(subject.cached_some_cached_instance_method).to eq 20
+      end
+    }
+  end
 end

--- a/spec/trax/model/mixins/cached_methods_spec.rb
+++ b/spec/trax/model/mixins/cached_methods_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe ::Trax::Model::Mixins::CachedMethods do
+  context "cached class methods" do
+    subject {
+      ::Product
+    }
+
+    let(:keys_in_cache) { ::Trax::Model.cache.instance_variable_get(:@data).keys }
+
+    it {
+      expect(subject.cached_inventory_cost).to eq 0
+      expect(keys_in_cache).to include("product.inventory_cost")
+      subject.inventory_cost = 20
+      expect(subject.cached_inventory_cost).to eq 0
+
+      Timecop.freeze(Time.now + 30.minutes) do
+        expect(subject.cached_inventory_cost).to eq 20
+      end
+    }
+
+    context "method that accepts args" do
+      let!(:product_1) { Product.create(:in_stock_quantity => 5) }
+      let!(:product_2) { Product.create(:in_stock_quantity => 5) }
+      let!(:product_3) { Product.create(:in_stock_quantity => 1) }
+
+      it {
+        expect(subject.cached_in_stock_quantities([product_1.id])).to eq 5
+        expect(subject.cached_in_stock_quantities([product_1.id, product_2.id])).to eq 10
+        expect(subject.cached_in_stock_quantities([product_3.id])).to eq 1
+        expect(subject.cached_in_stock_quantities([product_1.id, product_3.id])).to eq 6
+        expect(keys_in_cache).to include("product.in_stock_quantities/[1]")
+        expect(keys_in_cache).to include("product.in_stock_quantities/[1, 2]")
+        expect(keys_in_cache).to include("product.in_stock_quantities/[1, 3]")
+
+        product_3.update_attributes(:in_stock_quantity => 20)
+        product_3.reload
+        expect(subject.cached_in_stock_quantities([product_3.id])).to eq 1
+
+        Timecop.freeze(Time.now + 30.minutes) do
+          expect(subject.cached_in_stock_quantities([product_3.id])).to eq 20
+        end
+      }
+    end
+  end
+end

--- a/spec/trax/model/mixins/cached_methods_spec.rb
+++ b/spec/trax/model/mixins/cached_methods_spec.rb
@@ -89,13 +89,13 @@ describe ::Trax::Model::Mixins::CachedMethods do
     let(:keys_in_cache) { ::Trax::Model.cache.instance_variable_get(:@data).keys }
 
     it {
-      expect(subject.cached_some_cached_instance_method).to eq 0
+      expect(subject.some_instance_method).to eq 0
       expect(keys_in_cache).to include("product#some_cached_instance_method/#{subject.id}")
       subject.class.inventory_cost = 20
-      expect(subject.cached_some_cached_instance_method).to eq 0
+      expect(subject.some_instance_method).to eq 0
 
       Timecop.freeze(Time.now + 30.minutes) do
-        expect(subject.cached_some_cached_instance_method).to eq 20
+        expect(subject.some_instance_method).to eq 20
       end
     }
   end

--- a/trax_model.gemspec
+++ b/trax_model.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "timecop"  
   spec.add_development_dependency "rspec-pride"
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "simplecov"

--- a/trax_model.gemspec
+++ b/trax_model.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "timecop"  
+  spec.add_development_dependency "timecop"
   spec.add_development_dependency "rspec-pride"
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "simplecov"
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-bundler', '~> 2'
   spec.add_development_dependency 'listen', '~> 3.0.3'
   spec.add_development_dependency 'rb-fsevent', '~> 0.9.6'
+  spec.add_development_dependency "ruby_dig"
 end


### PR DESCRIPTION
Fixes issue with cache key expiration, adds new cached_methods mixin. No longer need to manually instantiate Trax::Model::CacheKey, Trax::Model now overwrites cache.fetch to turn the call into a cache key, provides a better dsl for cached methods so the manual fetch block isn't really necessary