### PR TITLE
Add foreign key functionality to cached relations

### DIFF
--- a/lib/trax/model/mixins/cached_relations.rb
+++ b/lib/trax/model/mixins/cached_relations.rb
@@ -10,8 +10,8 @@ module Trax
           def cached_belongs_to(relation_name, **options)
             define_method("cached_#{relation_name}") do
               relation = self.class.reflect_on_association(relation_name)
-              foreign_key = (options.delete(:foreign_key) || relation.foreign_key || "#{relation.name}_id").to_sym
-              params = { :id => self.__send__(foreign_key) }.merge(options)
+              foreign_key = (relation.foreign_key || "#{relation.name}_id").to_sym
+              params = { :id => self.__send__(foreign_key) }.merge(options.except(:foreign_key))
               relation.klass.cached_find_by(**params)
             end
 
@@ -26,8 +26,8 @@ module Trax
           def cached_has_one(relation_name, **options)
             define_method("cached_#{relation_name}") do
               relation = self.class.reflect_on_association(relation_name)
-              foreign_key = (options.delete(:foreign_key) || relation.foreign_key || "#{relation.name}_id").to_sym
-              params = { foreign_key => self.__send__(:id) }.merge(options)
+              foreign_key = (relation.foreign_key || "#{relation.name}_id").to_sym
+              params = { foreign_key => self.__send__(:id) }.merge(options.except(:foreign_key))
               params.merge!(relation.klass.instance_eval(&relation.scope).where_values_hash.symbolize_keys) if relation.scope
               relation.klass.cached_find_by(**params)
             end
@@ -44,8 +44,8 @@ module Trax
           def cached_has_many(relation_name, **options)
             define_method("cached_#{relation_name}") do
               relation = self.class.reflect_on_association(relation_name)
-              foreign_key = options.delete(:foreign_key) || :"#{relation.foreign_key}"
-              params = {foreign_key => self.__send__(:id)}.merge(options)
+              foreign_key = :"#{relation.foreign_key}"
+              params = {foreign_key => self.__send__(:id)}.merge(options.except(:foreign_key))
               relation.klass.cached_where(**params)
             end
 

--- a/lib/trax/model/mixins/cached_relations.rb
+++ b/lib/trax/model/mixins/cached_relations.rb
@@ -10,7 +10,7 @@ module Trax
           def cached_belongs_to(relation_name, **options)
             define_method("cached_#{relation_name}") do
               relation = self.class.reflect_on_association(relation_name)
-              foreign_key = (relation.foreign_key || "#{relation.name}_id").to_sym
+              foreign_key = (options.delete(:foreign_key) || relation.foreign_key || "#{relation.name}_id").to_sym
               params = { :id => self.__send__(foreign_key) }.merge(options)
               relation.klass.cached_find_by(**params)
             end
@@ -26,7 +26,7 @@ module Trax
           def cached_has_one(relation_name, **options)
             define_method("cached_#{relation_name}") do
               relation = self.class.reflect_on_association(relation_name)
-              foreign_key = (relation.foreign_key || "#{relation.name}_id").to_sym
+              foreign_key = (options.delete(:foreign_key) || relation.foreign_key || "#{relation.name}_id").to_sym
               params = { foreign_key => self.__send__(:id) }.merge(options)
               params.merge!(relation.klass.instance_eval(&relation.scope).where_values_hash.symbolize_keys) if relation.scope
               relation.klass.cached_find_by(**params)
@@ -44,7 +44,7 @@ module Trax
           def cached_has_many(relation_name, **options)
             define_method("cached_#{relation_name}") do
               relation = self.class.reflect_on_association(relation_name)
-              foreign_key = :"#{relation.foreign_key}"
+              foreign_key = options.delete(:foreign_key) || :"#{relation.foreign_key}"
               params = {foreign_key => self.__send__(:id)}.merge(options)
               relation.klass.cached_where(**params)
             end


### PR DESCRIPTION
Currently, if attempting to use foreign_key option on a cached relation a "ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column census_surveys.foreign_key does not exist" is thrown. This is due to the foreign_key key value pair still being a part of options when passed to cached_find_by.

1) Removes foreign_key key/value pair from options prior to merge
