### PR TITLE
fix actual destroy method by deferring inclusion until after

### DIFF
--- a/lib/trax/model/mixins/restorable.rb
+++ b/lib/trax/model/mixins/restorable.rb
@@ -4,6 +4,12 @@ module Trax
       module Restorable
         extend ::Trax::Model::Mixin
 
+        module DeferredInstanceMethods
+          def destroy
+            self.update_attributes(self.class.restorable_config.field => true, self.class.restorable_config.timestamp_field => ::DateTime.now)
+          end
+        end
+
         define_configuration_options! do
           option :field, :default => :is_deleted
           option :timestamp_field, :default => :deleted_at
@@ -57,18 +63,14 @@ module Trax
           end
         end
 
-        def destroy
-          self.update_attributes(self.class.restorable_config.field => true, self.class.restorable_config.timestamp_field => ::DateTime.now)
-        end
-
         def restore
           self.update_attributes(self.class.restorable_config.field => false, self.class.restorable_config.timestamp_field => ::DateTime.now)
         end
 
         def self.apply_mixin(target, options)
           target.restorable_config.merge!(options)
-
           target.setup_restorable!
+          target.include(::Trax::Model::Mixins::Restorable::DeferredInstanceMethods)
         end
       end
     end

--- a/spec/trax/model/mixins/restorable_spec.rb
+++ b/spec/trax/model/mixins/restorable_spec.rb
@@ -16,6 +16,11 @@ describe ::Trax::Model::Mixins::Restorable do
       subject.restore
       expect(subject.deleted).to be false
     end
+
+    it "allows subject to be really destroyed via bang" do
+      subject.destroy!
+      expect{ subject.reload }.to raise_error(::ActiveRecord::RecordNotFound)
+    end
   end
 
   context "scopes" do


### PR DESCRIPTION
Fixes aliasing of destroy! from pointing back to already overwritten method