### PR TITLE
add relation_scopes mixin

### DIFF
--- a/lib/trax/model.rb
+++ b/lib/trax/model.rb
@@ -93,6 +93,7 @@ module Trax
       ::Trax::Model::Mixins::FieldScopes
       ::Trax::Model::Mixins::Freezable
       ::Trax::Model::Mixins::IdScopes
+      ::Trax::Model::Mixins::RelationScopes
       ::Trax::Model::Mixins::Restorable
       ::Trax::Model::Mixins::SortScopes
       ::Trax::Model::Mixins::StiEnum

--- a/lib/trax/model/mixins.rb
+++ b/lib/trax/model/mixins.rb
@@ -10,6 +10,7 @@ module Trax
       autoload :Freezable
       autoload :IdScopes
       autoload :Restorable
+      autoload :RelationScopes
       autoload :SortScopes
       autoload :StiEnum
       autoload :UniqueId

--- a/lib/trax/model/mixins/relation_scopes.rb
+++ b/lib/trax/model/mixins/relation_scopes.rb
@@ -1,0 +1,30 @@
+module Trax
+  module Model
+    module Mixins
+      module RelationScopes
+        extend ::Trax::Model::Mixin
+
+        mixed_in do |**options|
+          options.each_pair do |scope_name, scope_options|
+            define_model_relationship_scope(scope_name, scope_options)
+          end
+        end
+
+        module ClassMethods
+          def define_model_relationship_scope(scope_name, scope_options)
+            scope_options[:model] = scope_options[:class_name].is_a?(String) ? scope_options[:class_name].constantize : scope_options[:class_name]
+            define_model_relationship_scope_for_field(scope_name, **scope_options)
+          end
+
+          private
+          def define_model_relationship_scope_for_field(scope_name, scope:, model:, source_scope:, **rest)
+            define_singleton_method(scope_name) do |*values|
+              values.flat_compact_uniq!
+              self.__send__(scope, model.__send__(source_scope, values))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -52,7 +52,13 @@ class Product < ::ActiveRecord::Base
   cached_instance_method(:some_cached_instance_method, :as => :some_instance_method, :expires_in => 20.minutes)
 
   mixins :field_scopes => {
-    :by_id => true
+    :by_id => true,
+    :by_name => true,
+    :by_name_matches => { :field => :name, :type => :match }
+  }
+
+  mixins :relation_scopes => {
+    :by_category_name_matches => { :class_name => "Category", :source_scope => :by_name_matches, :scope => :by_category_id  }
   }
 
   belongs_to :category
@@ -77,6 +83,10 @@ class Category < ::ActiveRecord::Base
   include ::Trax::Model::Attributes::Dsl
 
   mixins :sort_scopes => true
+
+  mixins :field_scopes => {
+    :by_name_matches => { :field => :name, :type => :match }
+  }
 
   has_many :products
 

--- a/spec/trax/model/mixins/relation_scopes_spec.rb
+++ b/spec/trax/model/mixins/relation_scopes_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe ::Trax::Model::Mixins::RelationScopes do
+  let!(:skate_shoes_category) { ::Category.create(:name => "skate_shoes") }
+  let!(:running_shoes_category) { ::Category.create(:name => "running_shoes") }
+  let!(:ray_shoes_category) { ::Category.create(:name => "RAY_shoes") }
+  let!(:skate_shoes_product_one) { ::Product.create(:name => "Command", :category => skate_shoes_category, :in_stock_quantity => 5, :on_order_quantity => 3) }
+  let!(:skate_shoes_product_two) { ::Product.create(:name => "Villan", :category => skate_shoes_category, :in_stock_quantity => 3, :on_order_quantity => 2) }
+  let!(:running_shoes_product_one) { ::Product.create(:name => "some_running_shoes", :category => running_shoes_category, :in_stock_quantity => 2, :on_order_quantity => 0) }
+  let!(:ray_shoes_product_one) { ::Product.create(:name => "some_ray_shoes", :category => ray_shoes_category, :in_stock_quantity => 1, :on_order_quantity => 0) }
+
+  subject { ::Product }
+
+  ##todo:
+
+  context "type 'matches'" do
+    it { expect(subject.by_category_name_matches("skate")).to be_present }
+    # it { expect(subject.by_title(known_title.downcase)).to be_empty }
+    # it { expect(subject.by_title(known_title.upcase)).to be_empty }
+    #
+    # it { expect(subject.by_title(*known_titles)).to be_present }
+    # it { expect(subject.by_title(*known_titles.map(&:downcase))).to be_empty }
+    # it { expect(subject.by_title(*known_titles.map(&:upcase))).to be_empty }
+    #
+    # it { expect(subject.by_title(known_titles_relation)).to be_present }
+    # it { expect(subject.by_title(known_titles_downcased_relation)).to be_empty }
+    # it { expect(subject.by_title(known_titles_upcased_relation)).to be_empty }
+    #
+    # it { expect(subject.by_title(unknown_title)).to be_empty }
+  end
+
+  context "type 'where_lower'" do
+    # it { expect(subject.by_title_case_insensitive(known_title)).to be_present }
+    # it { expect(subject.by_title_case_insensitive(known_title.downcase)).to be_present }
+    # it { expect(subject.by_title_case_insensitive(known_title.upcase)).to be_present }
+    #
+    # it { expect(subject.by_title_case_insensitive(*known_titles)).to be_present }
+    # it { expect(subject.by_title_case_insensitive(*known_titles.map(&:downcase))).to be_present }
+    # it { expect(subject.by_title_case_insensitive(*known_titles.map(&:upcase))).to be_present }
+    #
+    # it { expect(subject.by_title_case_insensitive(known_titles_relation)).to be_empty }
+    # it { expect(subject.by_title_case_insensitive(known_titles_downcased_relation)).to be_present }
+    # it { expect(subject.by_title_case_insensitive(known_titles_upcased_relation)).to be_empty }
+    #
+    # it { expect(subject.by_title_case_insensitive(unknown_title)).to be_empty }
+  end
+end


### PR DESCRIPTION
add a relation_scopes mixin
```
mixins :relation_scopes => {
    :by_category_name_matches => { :class_name => "Category", :source_scope => :by_name_matches, :scope => :by_category_id  }
  }```

which is the equivalent of

```
scope :by_category_name_matches, lambda{|*values|
  ids = Category.by_name_matches(values).select(:id)
  by_category_id(ids)
}
```